### PR TITLE
Add email deliverability diagram SVGs

### DIFF
--- a/email-deliverability/diagrams/domain-vs-ip-reputation.svg
+++ b/email-deliverability/diagrams/domain-vs-ip-reputation.svg
@@ -1,0 +1,435 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:cc="http://creativecommons.org/ns#"
+     width="100%"
+     viewBox="0 0 1200 1060"
+     xml:lang="en"
+     preserveAspectRatio="xMidYMid meet"
+     role="img"
+     aria-labelledby="title desc"
+     data-source="InboxAlly Deliverability Research">
+
+<title id="title">Domain Reputation vs IP Reputation</title>
+
+<desc id="desc">
+Deep comparison of domain reputation and IP reputation in email deliverability. IP reputation is a legacy,
+secondary signal shared across all senders on the same IP address, influenced by complaint rates, spam trap
+hits, volume patterns, and blocklist status. It resets when switching ESPs and is diluted by other senders on
+shared infrastructure. Domain reputation is the primary modern signal, unique to the sender's domain and
+portable across ESPs. It is influenced by engagement rate, authentication alignment, content quality, complaint
+ratio, and domain age. Domain reputation carries increasing weight in modern filtering while IP reputation
+carries declining weight. Both signals combine into a reputation score that determines whether messages reach
+the inbox, promotions tab, or spam folder.
+</desc>
+
+<metadata>
+<rdf:RDF>
+  <cc:Work rdf:about="">
+    <dc:title>Domain Reputation vs IP Reputation Comparison</dc:title>
+    <dc:creator>InboxAlly</dc:creator>
+    <dc:source>https://www.inboxally.com</dc:source>
+    <dc:subject>domain reputation, IP reputation, email deliverability, shared IP, dedicated IP, ESP migration, SPF, DKIM, DMARC, engagement rate, complaint ratio, spam traps, blocklists, inbox placement, spam filtering, sender reputation</dc:subject>
+    <dc:description>Side-by-side comparison showing how domain reputation (primary, portable, sender-controlled) and IP reputation (secondary, shared, ESP-dependent) differ across five dimensions and combine into filtering decisions.</dc:description>
+    <cc:license rdf:resource="https://creativecommons.org/licenses/by/4.0/" />
+  </cc:Work>
+</rdf:RDF>
+</metadata>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Domain Reputation vs IP Reputation",
+  "description": "How mailbox providers evaluate and weigh domain reputation against IP reputation when filtering email.",
+  "publisher": {
+    "@type": "Organization",
+    "name": "InboxAlly",
+    "url": "https://www.inboxally.com"
+  },
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "IP Reputation Evaluation",
+      "text": "Mailbox providers assess IP reputation based on complaint rates, spam trap hits, volume patterns, and blocklist status. This signal is shared across all senders on the same IP, resets when switching ESPs, and carries declining weight in modern filtering."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Domain Reputation Evaluation",
+      "text": "Mailbox providers assess domain reputation based on engagement rate, authentication alignment (SPF, DKIM, DMARC), content quality, complaint ratio, and domain age. This signal is unique to the sender, follows across ESP changes, and carries increasing weight in modern filtering."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Combined Reputation Score",
+      "text": "Both reputation signals combine into an overall reputation score, with domain reputation typically weighted more heavily than IP reputation in modern filtering systems."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Placement Decision",
+      "text": "The combined reputation score determines whether messages are placed in the inbox, promotions tab, or spam folder."
+    }
+  ]
+}
+</script>
+
+<style>
+  /* === Light mode === */
+  .bg { fill: #F1F0ED; }
+  .header-bar { fill: #292929; }
+  .header-text { font-family: Georgia, "Times New Roman", serif; font-size: 24px; fill: #FFFFFF; dominant-baseline: middle; }
+  .header-sub { font-family: Arial, Helvetica, sans-serif; font-size: 13px; fill: #DDEFFF; letter-spacing: 1px; dominant-baseline: middle; }
+
+  /* Column containers */
+  .col-ip { fill: #FFFFFF; stroke: #292929; stroke-width: 1; opacity: 0.5; }
+  .col-domain { fill: #DDEFFF; stroke: #0062FF; stroke-width: 1.5; }
+  .col-domain-inner { fill: none; stroke: #0062FF; stroke-width: 1; opacity: 0.12; }
+
+  /* Column headers */
+  .col-header-ip { fill: #292929; }
+  .col-header-domain { fill: #0062FF; }
+  .col-header-text { font-family: Arial, Helvetica, sans-serif; fill: #FFFFFF; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .col-header-sub { font-family: Arial, Helvetica, sans-serif; fill: #FFFFFF; font-size: 12px; text-anchor: middle; dominant-baseline: middle; opacity: 0.7; }
+
+  /* Row labels */
+  .row-label { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 11px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; letter-spacing: 1px; opacity: 0.35; }
+  .row-divider { stroke: #292929; stroke-width: 0.5; opacity: 0.1; }
+
+  /* Content text */
+  .cell-title { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 15px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .cell-desc { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 12px; text-anchor: middle; dominant-baseline: middle; opacity: 0.55; }
+  .cell-title-domain { font-family: Arial, Helvetica, sans-serif; fill: #0062FF; font-size: 15px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+
+  /* Trend indicators */
+  .trend-declining { font-family: Arial, Helvetica, sans-serif; fill: #FF3333; font-size: 13px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .trend-increasing { font-family: Arial, Helvetica, sans-serif; fill: #0062FF; font-size: 13px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+
+  /* Score box */
+  .score-box { fill: #0062FF; stroke: none; }
+  .score-text { font-family: Arial, Helvetica, sans-serif; fill: #FFFFFF; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .score-sub { font-family: Arial, Helvetica, sans-serif; fill: #FFFFFF; font-size: 11px; text-anchor: middle; dominant-baseline: middle; opacity: 0.7; }
+
+  /* Convergence labels */
+  .weight-label { font-family: Arial, Helvetica, sans-serif; font-size: 12px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .weight-secondary { fill: #292929; opacity: 0.4; }
+  .weight-primary { fill: #0062FF; }
+
+  /* Outcomes */
+  .outcome-box { fill: #FFFFFF; stroke: #292929; stroke-width: 1.5; }
+  .outcome-inbox { fill: #DDEFFF; stroke: #0062FF; stroke-width: 2; }
+  .spam-outcome { fill: #FFF0F0; stroke: #FF3333; stroke-width: 2; }
+  .outcome-group { fill: none; stroke: #292929; stroke-width: 1; stroke-dasharray: 4 3; opacity: 0.2; }
+  .outcome-group-label { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 11px; text-anchor: end; dominant-baseline: middle; opacity: 0.35; }
+  .outcome-label { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .outcome-sub { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 13px; text-anchor: middle; dominant-baseline: middle; opacity: 0.45; }
+  .spam-label { font-family: Arial, Helvetica, sans-serif; fill: #FF3333; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+
+  /* Arrows and connectors */
+  .arrow-secondary { stroke: #292929; stroke-width: 2; opacity: 0.35; marker-end: url(#arrow-gray); }
+  .arrow-primary { stroke: #0062FF; stroke-width: 3; marker-end: url(#arrow-blue); }
+  .arrow-branch { stroke: #0062FF; stroke-width: 2; marker-end: url(#arrow-blue); }
+  .connector-dot { fill: #0062FF; }
+  .connector-dot-muted { fill: #292929; opacity: 0.35; }
+
+  /* Decorative */
+  .diag-line { stroke: #0062FF; stroke-width: 0.5; opacity: 0.06; }
+  .attribution { font-family: Arial, Helvetica, sans-serif; font-size: 11px; fill: #292929; opacity: 0.4; }
+  .badge { fill: #FF3333; }
+  .badge-text { font-family: Arial, Helvetica, sans-serif; font-size: 10px; font-weight: 700; fill: #FFFFFF; text-anchor: middle; dominant-baseline: middle; }
+  .vs-text { font-family: Georgia, "Times New Roman", serif; fill: #292929; font-size: 28px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; opacity: 0.08; }
+
+  /* === Dark mode === */
+  @media (prefers-color-scheme: dark) {
+    .bg { fill: #1A1A1A; }
+    .header-bar { fill: #0D0D0D; }
+    .col-ip { fill: #222222; stroke: #555555; }
+    .col-domain { fill: #1A2A3A; stroke: #4D9AFF; }
+    .col-domain-inner { stroke: #4D9AFF; opacity: 0.06; }
+    .col-header-ip { fill: #333333; }
+    .col-header-domain { fill: #4D9AFF; }
+    .row-label { fill: #888888; }
+    .row-divider { stroke: #555555; }
+    .cell-title { fill: #E8E8E8; }
+    .cell-desc { fill: #A0A0A0; }
+    .cell-title-domain { fill: #4D9AFF; }
+    .trend-declining { fill: #FF6666; }
+    .trend-increasing { fill: #4D9AFF; }
+    .score-box { fill: #4D9AFF; }
+    .weight-secondary { fill: #888888; }
+    .weight-primary { fill: #4D9AFF; }
+    .outcome-box { fill: #2A2A2A; stroke: #666666; }
+    .outcome-inbox { fill: #1A2A3A; stroke: #4D9AFF; }
+    .spam-outcome { fill: #3A1A1A; stroke: #FF6666; }
+    .outcome-group { stroke: #555555; }
+    .outcome-group-label { fill: #666666; }
+    .outcome-label { fill: #E8E8E8; }
+    .outcome-sub { fill: #888888; }
+    .spam-label { fill: #FF6666; }
+    .arrow-secondary { stroke: #666666; }
+    .arrow-primary { stroke: #4D9AFF; }
+    .arrow-branch { stroke: #4D9AFF; }
+    .connector-dot { fill: #4D9AFF; }
+    .connector-dot-muted { fill: #666666; }
+    .diag-line { stroke: #4D9AFF; opacity: 0.04; }
+    .attribution { fill: #888888; }
+    .vs-text { fill: #555555; }
+  }
+</style>
+
+<defs>
+  <marker id="arrow-blue" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+    <polygon points="0 0, 8 3, 0 6" fill="#0062FF"/>
+  </marker>
+  <marker id="arrow-gray" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+    <polygon points="0 0, 8 3, 0 6" fill="#292929" opacity="0.35"/>
+  </marker>
+  <clipPath id="clip-canvas">
+    <rect x="0" y="0" width="1200" height="1060"/>
+  </clipPath>
+</defs>
+
+<!-- Background -->
+<rect class="bg" x="0" y="0" width="1200" height="1060"/>
+
+<!-- Diagonal line motif -->
+<g clip-path="url(#clip-canvas)" aria-hidden="true">
+  <line class="diag-line" x1="-50" y1="1060" x2="650" y2="0"/>
+  <line class="diag-line" x1="50" y1="1060" x2="750" y2="0"/>
+  <line class="diag-line" x1="150" y1="1060" x2="850" y2="0"/>
+  <line class="diag-line" x1="250" y1="1060" x2="950" y2="0"/>
+  <line class="diag-line" x1="350" y1="1060" x2="1050" y2="0"/>
+  <line class="diag-line" x1="450" y1="1060" x2="1150" y2="0"/>
+  <line class="diag-line" x1="550" y1="1060" x2="1250" y2="0"/>
+</g>
+
+<!-- Header bar -->
+<rect class="header-bar" x="0" y="0" width="1200" height="54"/>
+<text class="header-text" x="36" y="29">Domain Reputation vs IP Reputation</text>
+<text class="header-sub" x="1164" y="29" text-anchor="end">INBOXALLY DELIVERABILITY RESEARCH</text>
+
+<!-- Large VS watermark -->
+<text class="vs-text" x="600" y="420" aria-hidden="true">VS</text>
+
+<!-- ============================================================ -->
+<!-- IP REPUTATION COLUMN (left — secondary, muted) -->
+<!-- ============================================================ -->
+
+<g id="column-ip-reputation"
+   aria-label="IP Reputation: secondary signal, shared across senders, declining weight in modern filtering"
+   data-step="comparison"
+   data-label="IP Reputation"
+   data-description="Legacy reputation signal based on sending IP address, shared across all senders on the same infrastructure">
+
+  <!-- Column container -->
+  <rect class="col-ip" x="60" y="78" width="500" height="650" rx="14"/>
+
+  <!-- Column header -->
+  <rect class="col-header-ip" x="60" y="78" width="500" height="60" rx="14"/>
+  <rect class="col-header-ip" x="60" y="108" width="500" height="30"/>
+  <text class="col-header-text" x="310" y="102">IP Reputation</text>
+  <text class="col-header-sub" x="310" y="126">Secondary Signal</text>
+
+  <!-- Row 1: Scope -->
+  <text class="cell-title" x="310" y="176">Shared across all senders on IP</text>
+  <text class="cell-desc" x="310" y="196">Multiple senders share the same IP reputation</text>
+
+  <line class="row-divider" x1="90" y1="218" x2="530" y2="218" aria-hidden="true"/>
+
+  <!-- Row 2: Key Signals -->
+  <text class="cell-title" x="310" y="244">Complaint Rate · Spam Traps</text>
+  <text class="cell-title" x="310" y="266">Volume Patterns · Blocklists</text>
+  <text class="cell-desc" x="310" y="290">Aggregate behavior across all senders on IP</text>
+
+  <line class="row-divider" x1="90" y1="312" x2="530" y2="312" aria-hidden="true"/>
+
+  <!-- Row 3: Portability -->
+  <text class="cell-title" x="310" y="342">Resets when you switch ESP</text>
+  <text class="cell-desc" x="310" y="362">New IP = new reputation to build from scratch</text>
+
+  <line class="row-divider" x1="90" y1="384" x2="530" y2="384" aria-hidden="true"/>
+
+  <!-- Row 4: Control -->
+  <text class="cell-title" x="310" y="414">Diluted by other senders</text>
+  <text class="cell-desc" x="310" y="434">Shared IPs mean others can damage your reputation</text>
+
+  <line class="row-divider" x1="90" y1="456" x2="530" y2="456" aria-hidden="true"/>
+
+  <!-- Row 5: Trend -->
+  <text class="trend-declining" x="310" y="486">↓ Declining weight</text>
+  <text class="cell-desc" x="310" y="506">Modern providers de-prioritize IP-based signals</text>
+
+  <line class="row-divider" x1="90" y1="528" x2="530" y2="528" aria-hidden="true"/>
+
+  <!-- Row 6: Implication -->
+  <text class="cell-title" x="310" y="560">Switching ESPs can reset IP reputation</text>
+  <text class="cell-desc" x="310" y="580">but does not fix underlying sending problems</text>
+
+  <!-- Faint icon watermark -->
+  <circle class="icon-pos" cx="490" cy="660" r="40" aria-hidden="true" style="fill:#292929; opacity:0.03;"/>
+
+</g>
+
+<!-- ============================================================ -->
+<!-- DOMAIN REPUTATION COLUMN (right — primary, prominent) -->
+<!-- ============================================================ -->
+
+<g id="column-domain-reputation"
+   aria-label="Domain Reputation: primary signal, unique to sender, increasing weight in modern filtering"
+   data-step="comparison"
+   data-label="Domain Reputation"
+   data-description="Primary modern reputation signal based on sending domain, unique to the sender and portable across infrastructure">
+
+  <!-- Column container -->
+  <rect class="col-domain" x="640" y="78" width="500" height="650" rx="14"/>
+  <rect class="col-domain-inner" x="644" y="82" width="492" height="642" rx="12"/>
+
+  <!-- Column header -->
+  <rect class="col-header-domain" x="640" y="78" width="500" height="60" rx="14"/>
+  <rect class="col-header-domain" x="640" y="108" width="500" height="30"/>
+  <text class="col-header-text" x="890" y="102">Domain Reputation</text>
+  <text class="col-header-sub" x="890" y="126">Primary Signal</text>
+
+  <!-- Row 1: Scope -->
+  <text class="cell-title-domain" x="890" y="176">Unique to your sending domain</text>
+  <text class="cell-desc" x="890" y="196">Your domain, your reputation — nobody else's</text>
+
+  <line class="row-divider" x1="670" y1="218" x2="1110" y2="218" aria-hidden="true"/>
+
+  <!-- Row 2: Key Signals -->
+  <text class="cell-title-domain" x="890" y="244">Engagement · Auth Alignment</text>
+  <text class="cell-title-domain" x="890" y="266">Content Quality · Complaint Ratio</text>
+  <text class="cell-desc" x="890" y="290">Signals you directly control through sending practices</text>
+
+  <line class="row-divider" x1="670" y1="312" x2="1110" y2="312" aria-hidden="true"/>
+
+  <!-- Row 3: Portability -->
+  <text class="cell-title-domain" x="890" y="342">Follows you across every ESP</text>
+  <text class="cell-desc" x="890" y="362">Switching providers does not reset domain reputation</text>
+
+  <line class="row-divider" x1="670" y1="384" x2="1110" y2="384" aria-hidden="true"/>
+
+  <!-- Row 4: Control -->
+  <text class="cell-title-domain" x="890" y="414">100% yours to build or damage</text>
+  <text class="cell-desc" x="890" y="434">No other sender can affect your domain reputation</text>
+
+  <line class="row-divider" x1="670" y1="456" x2="1110" y2="456" aria-hidden="true"/>
+
+  <!-- Row 5: Trend -->
+  <text class="trend-increasing" x="890" y="486">↑ Increasing weight</text>
+  <text class="cell-desc" x="890" y="506">Google, Microsoft, Yahoo increasingly prioritize domain signals</text>
+
+  <line class="row-divider" x1="670" y1="528" x2="1110" y2="528" aria-hidden="true"/>
+
+  <!-- Row 6: Implication -->
+  <text class="cell-title-domain" x="890" y="560">A damaged domain follows you everywhere</text>
+  <text class="cell-desc" x="890" y="580">Fixing domain reputation requires fixing sending behavior</text>
+
+  <!-- Faint icon watermark -->
+  <circle class="icon-pos" cx="1070" cy="660" r="40" aria-hidden="true"/>
+
+</g>
+
+<!-- ============================================================ -->
+<!-- ROW LABELS (center gutter) -->
+<!-- ============================================================ -->
+
+<g aria-hidden="true">
+  <text class="row-label" x="600" y="186">SCOPE</text>
+  <text class="row-label" x="600" y="266">KEY SIGNALS</text>
+  <text class="row-label" x="600" y="352">PORTABILITY</text>
+  <text class="row-label" x="600" y="424">CONTROL</text>
+  <text class="row-label" x="600" y="496">TREND</text>
+  <text class="row-label" x="600" y="570">IMPLICATION</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- CONVERGENCE ARROWS -->
+<!-- ============================================================ -->
+
+<!-- IP → Score (secondary, muted) -->
+<circle class="connector-dot-muted" cx="310" cy="728" r="3" aria-hidden="true"/>
+<line class="arrow-secondary" x1="310" y1="731" x2="500" y2="790"/>
+<text class="weight-label weight-secondary" x="370" y="775">Secondary</text>
+
+<!-- Domain → Score (primary, prominent) -->
+<circle class="connector-dot" cx="890" cy="728" r="3" aria-hidden="true"/>
+<line class="arrow-primary" x1="890" y1="731" x2="700" y2="790"/>
+<text class="weight-label weight-primary" x="830" y="775">Primary</text>
+
+<!-- ============================================================ -->
+<!-- REPUTATION SCORE -->
+<!-- ============================================================ -->
+
+<g id="reputation-score"
+   aria-label="Reputation score: combined from domain reputation (primary weight) and IP reputation (secondary weight)"
+   data-step="decision"
+   data-label="Reputation Score"
+   data-description="Combined reputation score weighted toward domain reputation">
+
+  <rect class="score-box" x="470" y="785" width="260" height="80" rx="12"/>
+  <text class="score-text" x="600" y="818">Reputation Score</text>
+  <text class="score-sub" x="600" y="842">Domain-weighted composite</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- BRANCHING TO OUTCOMES -->
+<!-- ============================================================ -->
+
+<circle class="connector-dot" cx="600" cy="865" r="3" aria-hidden="true"/>
+<line class="arrow-branch" x1="600" y1="868" x2="370" y2="902"/>
+<line class="arrow-branch" x1="600" y1="868" x2="600" y2="902"/>
+<line class="arrow-branch" x1="600" y1="868" x2="830" y2="902"/>
+
+<!-- ============================================================ -->
+<!-- OUTCOMES (grouped) -->
+<!-- ============================================================ -->
+
+<rect class="outcome-group" x="260" y="895" width="680" height="90" rx="14" aria-hidden="true"/>
+<text class="outcome-group-label" x="932" y="910">Placement outcomes</text>
+
+<g id="outcome-inbox"
+   aria-label="Outcome: Message delivered to inbox"
+   data-step="outcome"
+   data-label="Inbox"
+   data-description="Strong reputation results in inbox placement">
+  <rect class="outcome-inbox" x="275" y="910" width="195" height="64" rx="10"/>
+  <text class="outcome-label" x="372" y="935">Inbox</text>
+  <text class="outcome-sub" x="372" y="955">Primary delivery</text>
+</g>
+
+<g id="outcome-promotions"
+   aria-label="Outcome: Message delivered to promotions tab"
+   data-step="outcome"
+   data-label="Promotions"
+   data-description="Marketing content categorized into promotions tab">
+  <rect class="outcome-box" x="502" y="910" width="195" height="64" rx="10"/>
+  <text class="outcome-label" x="600" y="935">Promotions</text>
+  <text class="outcome-sub" x="600" y="955">Marketing tab</text>
+</g>
+
+<g id="outcome-spam"
+   aria-label="Outcome: Message delivered to spam folder"
+   data-step="outcome"
+   data-label="Spam"
+   data-description="Poor reputation results in spam folder placement">
+  <rect class="spam-outcome" x="730" y="910" width="195" height="64" rx="10"/>
+  <text class="spam-label" x="828" y="935">Spam</text>
+  <text class="outcome-sub" x="828" y="955">Spam folder</text>
+  <circle class="badge" cx="917" cy="917" r="9"/>
+  <text class="badge-text" x="917" y="918">!</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- ATTRIBUTION -->
+<!-- ============================================================ -->
+
+<a href="https://www.inboxally.com">
+  <text class="attribution" x="36" y="1040">Source: InboxAlly · inboxally.com</text>
+</a>
+<text class="attribution" x="1164" y="1040" text-anchor="end">CC BY 4.0</text>
+
+</svg>

--- a/email-deliverability/diagrams/email-deliverability-flow.svg
+++ b/email-deliverability/diagrams/email-deliverability-flow.svg
@@ -1,0 +1,398 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:cc="http://creativecommons.org/ns#"
+     width="100%"
+     viewBox="0 0 1200 520"
+     xml:lang="en"
+     preserveAspectRatio="xMidYMid meet"
+     role="img"
+     aria-labelledby="title desc"
+     data-source="InboxAlly Deliverability Research">
+
+<title id="title">Email Deliverability Flow</title>
+
+<desc id="desc">
+Email deliverability pipeline: an email sender transmits a message that mailbox providers first
+authenticate using SPF, DKIM, and DMARC. The provider then evaluates the sender's historical
+reputation. Spam filtering algorithms analyze message content, links, authentication alignment,
+and reputation signals. Based on these signals the message is placed in the inbox, the promotions
+tab, or the spam folder. Recipient engagement signals such as opens, clicks, and spam complaints
+feed back into the sender reputation system and influence future filtering decisions.
+</desc>
+
+<metadata>
+<rdf:RDF>
+  <cc:Work rdf:about="">
+    <dc:title>Email Deliverability Flow Diagram</dc:title>
+    <dc:creator>InboxAlly</dc:creator>
+    <dc:source>https://www.inboxally.com</dc:source>
+    <dc:subject>Email deliverability, spam filtering, sender reputation, SPF, DKIM, DMARC, inbox placement, email engagement, spam complaints, promotions tab</dc:subject>
+    <dc:description>
+      Diagram illustrating the flow of an email through authentication, reputation evaluation,
+      spam filtering, and final placement outcomes with engagement feedback loop.
+    </dc:description>
+    <cc:license rdf:resource="https://creativecommons.org/licenses/by/4.0/" />
+  </cc:Work>
+</rdf:RDF>
+</metadata>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Email Deliverability Flow",
+  "description": "How mailbox providers authenticate senders, evaluate reputation, filter messages, determine placement, and use engagement feedback.",
+  "publisher": {
+    "@type": "Organization",
+    "name": "InboxAlly",
+    "url": "https://www.inboxally.com"
+  },
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Email Sender",
+      "text": "An email sender transmits a message using its sending infrastructure and domain."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Authentication",
+      "text": "Mailbox providers authenticate the sender using SPF, DKIM, and DMARC to verify identity and alignment."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Sender Reputation",
+      "text": "Mailbox providers evaluate the sender's historical reputation using signals such as engagement, complaints, and sending behavior."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Spam Filtering",
+      "text": "Spam filtering algorithms analyze message content, links, authentication alignment, and reputation signals to score the email."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Placement Outcomes",
+      "text": "Based on filtering signals the message is delivered to the inbox, promotions tab, or spam folder."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Recipient Engagement Feedback",
+      "text": "Opens, clicks, and spam complaints feed back into sender reputation and influence future filtering decisions."
+    }
+  ]
+}
+</script>
+
+<style>
+  /* === Base light mode === */
+  .bg { fill: #F1F0ED; }
+  .header-bar { fill: #292929; }
+  .header-text { font-family: Georgia, 'Times New Roman', serif; fill: #FFFFFF; font-size: 24px; letter-spacing: 0.5px; }
+  .header-sub { font-family: Arial, Helvetica, Calibri, sans-serif; fill: #FFFFFF; font-size: 13px; opacity: 0.5; letter-spacing: 1px; }
+  .stage-box { fill: #DDEFFF; stroke: #292929; stroke-width: 1.5; }
+  .stage-box-inner { fill: none; stroke: #0062FF; stroke-width: 1; opacity: 0.15; }
+  .label { font-family: Arial, Helvetica, Calibri, sans-serif; fill: #292929; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .sublabel { font-family: Arial, Helvetica, Calibri, sans-serif; fill: #292929; font-size: 13px; text-anchor: middle; dominant-baseline: middle; opacity: 0.6; }
+  .step-num { font-family: Arial, Helvetica, Calibri, sans-serif; fill: #0062FF; font-size: 14px; font-weight: 600; text-anchor: middle; dominant-baseline: middle; }
+  .icon-shape { fill: #0062FF; opacity: 0.12; }
+  .arrow-line { stroke: #0062FF; stroke-width: 2; marker-end: url(#arrow); }
+  .arrow-line-muted { stroke: #292929; stroke-width: 1.5; stroke-dasharray: 6 3; opacity: 0.25; }
+  .outcome-box { fill: #FFFFFF; stroke: #292929; stroke-width: 1.5; }
+  .outcome-inbox { fill: #DDEFFF; stroke: #0062FF; stroke-width: 2; }
+  .outcome-label { font-family: Arial, Helvetica, Calibri, sans-serif; fill: #292929; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .outcome-sublabel { font-family: Arial, Helvetica, Calibri, sans-serif; fill: #292929; font-size: 13px; text-anchor: middle; dominant-baseline: middle; opacity: 0.45; }
+  .spam-box { fill: #FFF0F0; stroke: #FF3333; stroke-width: 2; }
+  .spam-label { font-family: Arial, Helvetica, Calibri, sans-serif; fill: #FF3333; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .engagement-box { fill: #DDEFFF; stroke: #0062FF; stroke-width: 1.5; stroke-dasharray: 6 3; }
+  .feedback-path { stroke: #0062FF; stroke-width: 2; fill: none; stroke-dasharray: 8 4; marker-end: url(#arrow); opacity: 0.7; }
+  .loop-label { font-family: Arial, Helvetica, Calibri, sans-serif; fill: #0062FF; font-size: 12px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .diag-line { stroke: #0062FF; stroke-width: 0.5; opacity: 0.06; }
+  .attribution { font-family: Arial, Helvetica, Calibri, sans-serif; font-size: 11px; fill: #292929; opacity: 0.4; }
+  .badge-circle { fill: #FF3333; }
+  .badge-text { font-family: Arial, Helvetica, Calibri, sans-serif; fill: #FFFFFF; font-size: 10px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .connector-dot { fill: #0062FF; }
+  .pipeline-axis { stroke: #D8D8D5; stroke-width: 2; opacity: 0.6; }
+  .decision-node { fill: #0062FF; }
+  .decision-label { font-family: Arial, Helvetica, Calibri, sans-serif; fill: #292929; font-size: 12px; text-anchor: middle; dominant-baseline: middle; opacity: 0.5; }
+
+  /* === Dark mode === */
+  @media (prefers-color-scheme: dark) {
+    .bg { fill: #1A1A1A; }
+    .header-bar { fill: #0D0D0D; }
+    .stage-box { fill: #1A2A3A; stroke: #4D9AFF; stroke-width: 1; }
+    .stage-box-inner { stroke: #4D9AFF; opacity: 0.08; }
+    .label { fill: #E8E8E8; }
+    .sublabel { fill: #A0A0A0; }
+    .step-num { fill: #4D9AFF; }
+    .icon-shape { fill: #4D9AFF; opacity: 0.1; }
+    .arrow-line { stroke: #4D9AFF; }
+    .arrow-line-muted { stroke: #666666; }
+    .outcome-box { fill: #2A2A2A; stroke: #666666; }
+    .outcome-inbox { fill: #1A2A3A; stroke: #4D9AFF; }
+    .outcome-label { fill: #E8E8E8; }
+    .outcome-sublabel { fill: #888888; }
+    .spam-box { fill: #3A1A1A; stroke: #FF6666; }
+    .spam-label { fill: #FF6666; }
+    .engagement-box { fill: #1A2A3A; stroke: #4D9AFF; }
+    .feedback-path { stroke: #4D9AFF; }
+    .loop-label { fill: #4D9AFF; }
+    .diag-line { stroke: #4D9AFF; opacity: 0.04; }
+    .attribution { fill: #888888; }
+    .connector-dot { fill: #4D9AFF; }
+    .pipeline-axis { stroke: #333333; }
+    .decision-node { fill: #4D9AFF; }
+    .decision-label { fill: #888888; }
+  }
+</style>
+
+<defs>
+  <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+    <polygon points="0 0, 8 3, 0 6" fill="#0062FF"/>
+  </marker>
+  <clipPath id="clip-canvas">
+    <rect x="0" y="0" width="1200" height="520" rx="0"/>
+  </clipPath>
+</defs>
+
+<!-- Background -->
+<rect class="bg" x="0" y="0" width="1200" height="520" rx="0"/>
+
+<!-- Diagonal line motif — subtle brand texture -->
+<g clip-path="url(#clip-canvas)" aria-hidden="true">
+  <line class="diag-line" x1="-50" y1="520" x2="350" y2="0"/>
+  <line class="diag-line" x1="50" y1="520" x2="450" y2="0"/>
+  <line class="diag-line" x1="150" y1="520" x2="550" y2="0"/>
+  <line class="diag-line" x1="250" y1="520" x2="650" y2="0"/>
+  <line class="diag-line" x1="350" y1="520" x2="750" y2="0"/>
+  <line class="diag-line" x1="450" y1="520" x2="850" y2="0"/>
+  <line class="diag-line" x1="550" y1="520" x2="950" y2="0"/>
+  <line class="diag-line" x1="650" y1="520" x2="1050" y2="0"/>
+  <line class="diag-line" x1="750" y1="520" x2="1150" y2="0"/>
+  <line class="diag-line" x1="850" y1="520" x2="1250" y2="0"/>
+  <line class="diag-line" x1="950" y1="520" x2="1350" y2="0"/>
+</g>
+
+<!-- Header bar -->
+<rect class="header-bar" x="0" y="0" width="1200" height="52"/>
+<text class="header-text" x="40" y="30">Email Deliverability Flow</text>
+<text class="header-sub" x="1160" y="30" text-anchor="end">INBOXALLY DELIVERABILITY RESEARCH</text>
+
+<!-- ============================================================ -->
+<!-- PIPELINE STAGES -->
+<!-- ============================================================ -->
+
+<!-- Pipeline axis — faint guide line anchoring the process flow -->
+<line class="pipeline-axis" x1="128" y1="235" x2="928" y2="235" aria-hidden="true"/>
+
+<!-- Step 1: Sender -->
+<g id="sender"
+   aria-label="Step 1: Email sender transmits message"
+   data-step="1"
+   data-label="Email Sender"
+   data-description="Originating sending infrastructure"
+   data-next="authentication">
+
+  <rect class="stage-box" x="48" y="190" width="160" height="90" rx="10"/>
+  <rect class="stage-box-inner" x="52" y="194" width="152" height="82" rx="8"/>
+
+  <!-- Envelope icon -->
+  <g class="icon-shape" aria-hidden="true">
+    <rect x="100" y="200" width="36" height="24" rx="3"/>
+    <polygon points="100,200 118,216 136,200"/>
+  </g>
+
+  <text class="step-num" x="128" y="210">01</text>
+  <text class="label" x="128" y="240">Email Sender</text>
+  <text class="sublabel" x="128" y="258">Sending infrastructure</text>
+</g>
+
+<!-- Step 2: Authentication -->
+<g id="authentication"
+   aria-label="Step 2: Authentication checks including SPF, DKIM, and DMARC"
+   data-step="2"
+   data-label="Authentication"
+   data-description="Mailbox provider verifies sender identity"
+   data-next="reputation">
+
+  <rect class="stage-box" x="268" y="190" width="180" height="90" rx="10"/>
+  <rect class="stage-box-inner" x="272" y="194" width="172" height="82" rx="8"/>
+
+  <!-- Shield icon -->
+  <g class="icon-shape" aria-hidden="true">
+    <path d="M348,198 L362,204 L362,216 C362,224 356,230 348,232 C340,230 334,224 334,216 L334,204 Z"/>
+  </g>
+
+  <text class="step-num" x="358" y="210">02</text>
+  <text class="label" x="358" y="237">Authentication</text>
+  <text class="sublabel" x="358" y="255">SPF · DKIM · DMARC</text>
+</g>
+
+<!-- Step 3: Reputation -->
+<g id="reputation"
+   aria-label="Step 3: Sender reputation evaluation"
+   data-step="3"
+   data-label="Sender Reputation"
+   data-description="Mailbox providers assess trust signals"
+   data-next="filtering">
+
+  <rect class="stage-box" x="508" y="190" width="180" height="90" rx="10"/>
+  <rect class="stage-box-inner" x="512" y="194" width="172" height="82" rx="8"/>
+
+  <!-- Star icon -->
+  <g class="icon-shape" aria-hidden="true">
+    <polygon points="598,198 602,210 614,210 604,218 608,230 598,222 588,230 592,218 582,210 594,210"/>
+  </g>
+
+  <text class="step-num" x="598" y="210">03</text>
+  <text class="label" x="598" y="237">Sender Reputation</text>
+  <text class="sublabel" x="598" y="255">Trust signal evaluation</text>
+</g>
+
+<!-- Step 4: Filtering -->
+<g id="filtering"
+   aria-label="Step 4: Spam filtering analysis"
+   data-step="4"
+   data-label="Spam Filtering"
+   data-description="Algorithms analyze message signals">
+
+  <rect class="stage-box" x="748" y="190" width="180" height="90" rx="10"/>
+  <rect class="stage-box-inner" x="752" y="194" width="172" height="82" rx="8"/>
+
+  <!-- Funnel icon -->
+  <g class="icon-shape" aria-hidden="true">
+    <polygon points="824,200 852,200 844,216 840,228 836,228 832,216"/>
+  </g>
+
+  <text class="step-num" x="838" y="210">04</text>
+  <text class="label" x="838" y="237">Spam Filtering</text>
+  <text class="sublabel" x="838" y="255">Content &amp; signal analysis</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- FLOW ARROWS -->
+<!-- ============================================================ -->
+
+<!-- Sender → Authentication -->
+<circle class="connector-dot" cx="208" cy="235" r="3"/>
+<line class="arrow-line" x1="211" y1="235" x2="268" y2="235"/>
+
+<!-- Authentication → Reputation -->
+<circle class="connector-dot" cx="448" cy="235" r="3"/>
+<line class="arrow-line" x1="451" y1="235" x2="508" y2="235"/>
+
+<!-- Reputation → Filtering -->
+<circle class="connector-dot" cx="688" cy="235" r="3"/>
+<line class="arrow-line" x1="691" y1="235" x2="748" y2="235"/>
+
+<!-- Filtering → Decision node -->
+<circle class="connector-dot" cx="928" cy="235" r="3"/>
+<line class="arrow-line" x1="931" y1="235" x2="949" y2="235"/>
+
+<!-- Classification decision node -->
+<g id="decision-placement"
+   aria-label="Decision: message placement classification"
+   data-step="decision"
+   data-label="Placement"
+   data-description="Classification decision routing message to final destination">
+
+  <circle class="decision-node" cx="958" cy="235" r="8"/>
+  <text class="decision-label" x="958" y="258">Placement</text>
+</g>
+
+<!-- Decision → Outcomes (branching) -->
+<line class="arrow-line" x1="966" y1="232" x2="998" y2="125"/>
+<line class="arrow-line" x1="966" y1="235" x2="998" y2="235"/>
+<line class="arrow-line" x1="966" y1="238" x2="998" y2="345"/>
+
+<!-- ============================================================ -->
+<!-- OUTCOMES -->
+<!-- ============================================================ -->
+
+<!-- Inbox -->
+<g id="outcome-inbox"
+   aria-label="Outcome: Message delivered to inbox"
+   data-step="outcome"
+   data-label="Inbox"
+   data-description="Message delivered to the primary inbox">
+
+  <rect class="outcome-inbox" x="998" y="83" width="170" height="85" rx="10"/>
+  <text class="outcome-label" x="1083" y="118">Inbox</text>
+  <text class="outcome-sublabel" x="1083" y="138">Primary delivery</text>
+</g>
+
+<!-- Promotions -->
+<g id="outcome-promotions"
+   aria-label="Outcome: Message delivered to promotions tab"
+   data-step="outcome"
+   data-label="Promotions"
+   data-description="Marketing message categorized into promotions tab">
+
+  <rect class="outcome-box" x="998" y="193" width="170" height="85" rx="10"/>
+  <text class="outcome-label" x="1083" y="228">Promotions</text>
+  <text class="outcome-sublabel" x="1083" y="248">Marketing tab</text>
+</g>
+
+<!-- Spam (with notification badge) -->
+<g id="outcome-spam"
+   aria-label="Outcome: Message delivered to spam folder"
+   data-step="outcome"
+   data-label="Spam"
+   data-description="Message classified as spam and routed to the spam folder">
+
+  <rect class="spam-box" x="998" y="303" width="170" height="85" rx="10"/>
+  <text class="spam-label" x="1083" y="338">Spam</text>
+  <text class="outcome-sublabel" x="1083" y="358">Spam folder</text>
+
+  <!-- Brand notification badge -->
+  <circle class="badge-circle" cx="1160" cy="310" r="9"/>
+  <text class="badge-text" x="1160" y="311">!</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- ENGAGEMENT + FEEDBACK LOOP -->
+<!-- ============================================================ -->
+
+<!-- Engagement node -->
+<g id="engagement"
+   aria-label="Feedback: Recipient engagement signals feed back into sender reputation"
+   data-step="feedback"
+   data-label="Recipient Engagement"
+   data-description="User behavior signals affecting reputation"
+   data-feeds="reputation">
+
+  <rect class="engagement-box" x="488" y="380" width="220" height="75" rx="10"/>
+  <text class="label" x="598" y="408">Recipient Engagement</text>
+  <text class="sublabel" x="598" y="428">Opens · Clicks · Complaints</text>
+</g>
+
+<!-- Feedback loop -->
+<g id="loop-feedback-reputation"
+   aria-label="Feedback loop: engagement signals feed into sender reputation">
+
+  <path class="feedback-path"
+        d="M488 405
+           C460 395, 455 330, 462 300
+           C469 270, 485 250, 508 242"/>
+  <text class="loop-label" x="448" y="345">Feeds into</text>
+  <text class="loop-label" x="448" y="358">reputation</text>
+</g>
+
+<!-- Guide line from outcomes area down to engagement -->
+<line class="arrow-line-muted" x1="998" y1="388" x2="708" y2="418"/>
+
+<!-- ============================================================ -->
+<!-- ATTRIBUTION -->
+<!-- ============================================================ -->
+
+<a href="https://www.inboxally.com">
+  <text x="40" y="505" class="attribution">Source: InboxAlly · inboxally.com</text>
+</a>
+<text x="1160" y="505" class="attribution" text-anchor="end">CC BY 4.0</text>
+
+</svg>

--- a/email-deliverability/diagrams/sender-reputation-model.svg
+++ b/email-deliverability/diagrams/sender-reputation-model.svg
@@ -1,0 +1,503 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:cc="http://creativecommons.org/ns#"
+     width="100%"
+     viewBox="0 0 1200 920"
+     xml:lang="en"
+     preserveAspectRatio="xMidYMid meet"
+     role="img"
+     aria-labelledby="title desc"
+     data-source="InboxAlly Deliverability Research">
+
+<title id="title">Sender Reputation Model</title>
+
+<desc id="desc">
+Sender reputation model: mailbox providers continuously evaluate a sender's cumulative trust score by
+weighing positive signals against negative signals. Positive signals include opens and reads, replies
+and forwards, spam folder rescues (not-spam corrections), consistent sending patterns, and clean list
+hygiene with low bounce rates. Negative signals include spam reports, hard bounces, spam trap hits,
+blocklist appearances, and consistently low engagement rates. These signals converge into a sender
+reputation score that determines whether messages are placed in the inbox, promotions tab, or spam
+folder. After placement, recipient behavior generates new engagement data — positive actions like
+opens and replies feed back as positive signals, while spam complaints feed back as negative signals,
+creating a continuous feedback cycle.
+</desc>
+
+<metadata>
+<rdf:RDF>
+  <cc:Work rdf:about="">
+    <dc:title>Sender Reputation Model Diagram</dc:title>
+    <dc:creator>InboxAlly</dc:creator>
+    <dc:source>https://www.inboxally.com</dc:source>
+    <dc:subject>sender reputation, email engagement, opens, reads, replies, forwards, spam rescues, not spam, sending patterns, list hygiene, bounce rate, spam complaints, spam traps, blocklists, low engagement, inbox placement, promotions tab, spam folder, email deliverability, reputation feedback cycle</dc:subject>
+    <dc:description>Balance model showing how positive and negative signals converge into a cumulative sender reputation score, determine placement outcomes, and cycle back through post-delivery engagement.</dc:description>
+    <cc:license rdf:resource="https://creativecommons.org/licenses/by/4.0/" />
+  </cc:Work>
+</rdf:RDF>
+</metadata>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Sender Reputation Model",
+  "description": "How mailbox providers weigh positive and negative signals to calculate sender reputation, determine placement, and use engagement feedback to update future scoring.",
+  "publisher": {
+    "@type": "Organization",
+    "name": "InboxAlly",
+    "url": "https://www.inboxally.com"
+  },
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Positive Signal Evaluation",
+      "text": "Mailbox providers observe positive signals including opens and reads, replies and forwards, spam folder rescues, consistent sending patterns, and clean list hygiene with low bounce rates. These signals strengthen sender reputation."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Negative Signal Evaluation",
+      "text": "Mailbox providers observe negative signals including spam reports, hard bounces, spam trap hits, blocklist appearances, and consistently low engagement rates. These signals weaken sender reputation."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Reputation Score Calculation",
+      "text": "Positive and negative signals are weighed against each other to produce a cumulative sender reputation score representing the provider's trust in the sender."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Placement Decision",
+      "text": "The reputation score influences whether messages are placed in the inbox, promotions tab, or spam folder."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Engagement Feedback Cycle",
+      "text": "After delivery, recipient actions generate new signals — opens, replies, and rescues strengthen reputation while spam complaints and disengagement weaken it — creating a continuous feedback cycle."
+    }
+  ]
+}
+</script>
+
+<style>
+  /* === Light mode === */
+  .bg { fill: #F1F0ED; }
+  .header-bar { fill: #292929; }
+  .header-text { font-family: Georgia, "Times New Roman", serif; font-size: 24px; fill: #FFFFFF; dominant-baseline: middle; }
+  .header-sub { font-family: Arial, Helvetica, sans-serif; font-size: 13px; fill: #DDEFFF; letter-spacing: 1px; dominant-baseline: middle; }
+
+  .pos-box { fill: #DDEFFF; stroke: #0062FF; stroke-width: 1.5; }
+  .pos-box-inner { fill: none; stroke: #0062FF; stroke-width: 1; opacity: 0.12; }
+  .neg-box { fill: #FFF0F0; stroke: #FF3333; stroke-width: 1.5; }
+  .neg-box-inner { fill: none; stroke: #FF3333; stroke-width: 1; opacity: 0.12; }
+  .column-label { font-family: Arial, Helvetica, sans-serif; fill: #0062FF; font-size: 14px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; letter-spacing: 1px; }
+  .column-label-neg { font-family: Arial, Helvetica, sans-serif; fill: #FF3333; font-size: 14px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; letter-spacing: 1px; }
+
+  .rep-box { fill: #0062FF; stroke: none; }
+  .rep-text { font-family: Arial, Helvetica, sans-serif; fill: #FFFFFF; font-size: 20px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .rep-sub { font-family: Arial, Helvetica, sans-serif; fill: #FFFFFF; font-size: 12px; text-anchor: middle; dominant-baseline: middle; opacity: 0.7; }
+  .converge-label { font-family: Arial, Helvetica, sans-serif; fill: #0062FF; font-size: 12px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .converge-label-neg { font-family: Arial, Helvetica, sans-serif; fill: #FF3333; font-size: 12px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+
+  .outcome-box { fill: #FFFFFF; stroke: #292929; stroke-width: 1.5; }
+  .outcome-inbox { fill: #DDEFFF; stroke: #0062FF; stroke-width: 2; }
+  .spam-outcome { fill: #FFF0F0; stroke: #FF3333; stroke-width: 2; }
+  .outcome-group { fill: none; stroke: #292929; stroke-width: 1; stroke-dasharray: 4 3; opacity: 0.2; }
+  .outcome-group-label { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 11px; text-anchor: end; dominant-baseline: middle; opacity: 0.35; }
+
+  .engagement-box { fill: #DDEFFF; stroke: #0062FF; stroke-width: 1.5; stroke-dasharray: 6 3; }
+
+  .label { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .sublabel { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 13px; text-anchor: middle; dominant-baseline: middle; opacity: 0.6; }
+  .signal-label { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 15px; font-weight: bold; text-anchor: start; dominant-baseline: middle; }
+  .signal-sub { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 11px; text-anchor: start; dominant-baseline: middle; opacity: 0.5; }
+  .signal-label-r { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 15px; font-weight: bold; text-anchor: end; dominant-baseline: middle; }
+  .signal-sub-r { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 11px; text-anchor: end; dominant-baseline: middle; opacity: 0.5; }
+  .signal-type { font-family: Arial, Helvetica, sans-serif; fill: #0062FF; font-size: 9px; font-weight: 600; text-anchor: start; dominant-baseline: middle; opacity: 0.6; letter-spacing: 0.5px; }
+  .signal-type-r { font-family: Arial, Helvetica, sans-serif; fill: #FF3333; font-size: 9px; font-weight: 600; text-anchor: end; dominant-baseline: middle; opacity: 0.6; letter-spacing: 0.5px; }
+  .outcome-label { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .outcome-sub { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 13px; text-anchor: middle; dominant-baseline: middle; opacity: 0.45; }
+  .spam-label { font-family: Arial, Helvetica, sans-serif; fill: #FF3333; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+
+  .arrow-pos { stroke: #0062FF; stroke-width: 2; marker-end: url(#arrow-blue); }
+  .arrow-neg { stroke: #FF3333; stroke-width: 2; marker-end: url(#arrow-red); }
+  .arrow-down { stroke: #0062FF; stroke-width: 2; marker-end: url(#arrow-blue); }
+  .arrow-branch { stroke: #0062FF; stroke-width: 2; marker-end: url(#arrow-blue); }
+  .feedback-pos { stroke: #0062FF; stroke-width: 2; fill: none; stroke-dasharray: 8 4; marker-end: url(#arrow-blue); opacity: 0.6; }
+  .feedback-neg { stroke: #FF3333; stroke-width: 2; fill: none; stroke-dasharray: 8 4; marker-end: url(#arrow-red); opacity: 0.6; }
+  .feedback-label { font-family: Arial, Helvetica, sans-serif; font-size: 11px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .feedback-label-pos { fill: #0062FF; }
+  .feedback-label-neg { fill: #FF3333; }
+
+  .connector-dot { fill: #0062FF; }
+  .connector-dot-neg { fill: #FF3333; }
+  .diag-line { stroke: #0062FF; stroke-width: 0.5; opacity: 0.06; }
+  .attribution { font-family: Arial, Helvetica, sans-serif; font-size: 11px; fill: #292929; opacity: 0.4; }
+  .badge { fill: #FF3333; }
+  .badge-text { font-family: Arial, Helvetica, sans-serif; font-size: 10px; font-weight: 700; fill: #FFFFFF; text-anchor: middle; dominant-baseline: middle; }
+
+  /* === Dark mode === */
+  @media (prefers-color-scheme: dark) {
+    .bg { fill: #1A1A1A; }
+    .header-bar { fill: #0D0D0D; }
+    .pos-box { fill: #1A2A3A; stroke: #4D9AFF; stroke-width: 1; }
+    .pos-box-inner { stroke: #4D9AFF; opacity: 0.06; }
+    .neg-box { fill: #3A1A1A; stroke: #FF6666; stroke-width: 1; }
+    .neg-box-inner { stroke: #FF6666; opacity: 0.06; }
+    .column-label { fill: #4D9AFF; }
+    .column-label-neg { fill: #FF6666; }
+    .rep-box { fill: #4D9AFF; }
+    .converge-label { fill: #4D9AFF; }
+    .converge-label-neg { fill: #FF6666; }
+    .label { fill: #E8E8E8; }
+    .sublabel { fill: #A0A0A0; }
+    .signal-label { fill: #E8E8E8; }
+    .signal-sub { fill: #888888; }
+    .signal-label-r { fill: #E8E8E8; }
+    .signal-sub-r { fill: #888888; }
+    .signal-type { fill: #4D9AFF; }
+    .signal-type-r { fill: #FF6666; }
+    .outcome-box { fill: #2A2A2A; stroke: #666666; }
+    .outcome-inbox { fill: #1A2A3A; stroke: #4D9AFF; }
+    .spam-outcome { fill: #3A1A1A; stroke: #FF6666; }
+    .outcome-group { stroke: #555555; }
+    .outcome-group-label { fill: #666666; }
+    .engagement-box { fill: #1A2A3A; stroke: #4D9AFF; }
+    .outcome-label { fill: #E8E8E8; }
+    .outcome-sub { fill: #888888; }
+    .spam-label { fill: #FF6666; }
+    .arrow-pos { stroke: #4D9AFF; }
+    .arrow-neg { stroke: #FF6666; }
+    .arrow-down { stroke: #4D9AFF; }
+    .arrow-branch { stroke: #4D9AFF; }
+    .feedback-pos { stroke: #4D9AFF; }
+    .feedback-neg { stroke: #FF6666; }
+    .feedback-label-pos { fill: #4D9AFF; }
+    .feedback-label-neg { fill: #FF6666; }
+    .connector-dot { fill: #4D9AFF; }
+    .connector-dot-neg { fill: #FF6666; }
+    .diag-line { stroke: #4D9AFF; opacity: 0.04; }
+    .attribution { fill: #888888; }
+  }
+</style>
+
+<defs>
+  <marker id="arrow-blue" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+    <polygon points="0 0, 8 3, 0 6" fill="#0062FF"/>
+  </marker>
+  <marker id="arrow-red" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+    <polygon points="0 0, 8 3, 0 6" fill="#FF3333"/>
+  </marker>
+  <clipPath id="clip-canvas">
+    <rect x="0" y="0" width="1200" height="920"/>
+  </clipPath>
+</defs>
+
+<!-- Background -->
+<rect class="bg" x="0" y="0" width="1200" height="920"/>
+
+<!-- Diagonal line motif -->
+<g clip-path="url(#clip-canvas)" aria-hidden="true">
+  <line class="diag-line" x1="-50" y1="920" x2="550" y2="0"/>
+  <line class="diag-line" x1="50" y1="920" x2="650" y2="0"/>
+  <line class="diag-line" x1="150" y1="920" x2="750" y2="0"/>
+  <line class="diag-line" x1="250" y1="920" x2="850" y2="0"/>
+  <line class="diag-line" x1="350" y1="920" x2="950" y2="0"/>
+  <line class="diag-line" x1="450" y1="920" x2="1050" y2="0"/>
+  <line class="diag-line" x1="550" y1="920" x2="1150" y2="0"/>
+  <line class="diag-line" x1="650" y1="920" x2="1250" y2="0"/>
+</g>
+
+<!-- Header bar -->
+<rect class="header-bar" x="0" y="0" width="1200" height="54"/>
+<text class="header-text" x="36" y="29">Sender Reputation Model</text>
+<text class="header-sub" x="1164" y="29" text-anchor="end">INBOXALLY DELIVERABILITY RESEARCH</text>
+
+<!-- ============================================================ -->
+<!-- POSITIVE SIGNALS (left column) -->
+<!-- ============================================================ -->
+
+<text class="column-label" x="220" y="88">STRENGTHENS REPUTATION</text>
+
+<!-- Positive 1: Opens & Reads — engagement -->
+<g id="signal-opens"
+   aria-label="Positive signal: opens and reads indicate active inbox engagement"
+   data-step="signal-positive"
+   data-label="Opens &amp; Reads"
+   data-description="Recipients opening and reading emails signals relevance to mailbox providers"
+   data-feeds="sender-reputation">
+  <rect class="pos-box" x="60" y="105" width="320" height="56" rx="8"/>
+  <rect class="pos-box-inner" x="64" y="109" width="312" height="48" rx="6"/>
+  <text class="signal-type" x="80" y="118">ENGAGEMENT</text>
+  <text class="signal-label" x="80" y="136">Opens &amp; Reads</text>
+  <text class="signal-sub" x="80" y="150">Active inbox engagement</text>
+</g>
+
+<!-- Positive 2: Replies & Forwards — engagement -->
+<g id="signal-replies"
+   aria-label="Positive signal: replies and forwards are the highest-trust engagement actions"
+   data-step="signal-positive"
+   data-label="Replies &amp; Forwards"
+   data-description="Replying to or forwarding a message is one of the strongest positive signals"
+   data-feeds="sender-reputation">
+  <rect class="pos-box" x="60" y="172" width="320" height="56" rx="8"/>
+  <rect class="pos-box-inner" x="64" y="176" width="312" height="48" rx="6"/>
+  <text class="signal-type" x="80" y="185">ENGAGEMENT</text>
+  <text class="signal-label" x="80" y="203">Replies &amp; Forwards</text>
+  <text class="signal-sub" x="80" y="217">Highest-trust user actions</text>
+</g>
+
+<!-- Positive 3: Spam Folder Rescues — correction -->
+<g id="signal-rescues"
+   aria-label="Positive signal: spam folder rescues explicitly correct filtering and restore trust"
+   data-step="signal-positive"
+   data-label="Spam Folder Rescues"
+   data-description="Recipients moving messages from spam to inbox is a direct positive correction signal"
+   data-feeds="sender-reputation">
+  <rect class="pos-box" x="60" y="239" width="320" height="56" rx="8"/>
+  <rect class="pos-box-inner" x="64" y="243" width="312" height="48" rx="6"/>
+  <text class="signal-type" x="80" y="252">CORRECTION</text>
+  <text class="signal-label" x="80" y="270">Spam Folder Rescues</text>
+  <text class="signal-sub" x="80" y="284">Not-spam corrections</text>
+</g>
+
+<!-- Positive 4: Consistent Sending Patterns — operational -->
+<g id="signal-consistency"
+   aria-label="Positive signal: consistent sending volume and patterns demonstrate reliable sender behavior"
+   data-step="signal-positive"
+   data-label="Consistent Sending Patterns"
+   data-description="Predictable volume, proper warming, and steady cadence signal reliable sender behavior"
+   data-feeds="sender-reputation">
+  <rect class="pos-box" x="60" y="306" width="320" height="56" rx="8"/>
+  <rect class="pos-box-inner" x="64" y="310" width="312" height="48" rx="6"/>
+  <text class="signal-type" x="80" y="319">OPERATIONAL</text>
+  <text class="signal-label" x="80" y="337">Consistent Sending Patterns</text>
+  <text class="signal-sub" x="80" y="351">Volume predictability &amp; warming</text>
+</g>
+
+<!-- Positive 5: Clean List Hygiene — operational -->
+<g id="signal-list-hygiene"
+   aria-label="Positive signal: clean list hygiene with low bounce rates indicates quality sending practices"
+   data-step="signal-positive"
+   data-label="Clean List Hygiene"
+   data-description="Low bounce rates and active valid recipients demonstrate responsible list management"
+   data-feeds="sender-reputation">
+  <rect class="pos-box" x="60" y="373" width="320" height="56" rx="8"/>
+  <rect class="pos-box-inner" x="64" y="377" width="312" height="48" rx="6"/>
+  <text class="signal-type" x="80" y="386">OPERATIONAL</text>
+  <text class="signal-label" x="80" y="404">Clean List Hygiene</text>
+  <text class="signal-sub" x="80" y="418">Low bounce rates &amp; valid recipients</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- NEGATIVE SIGNALS (right column) -->
+<!-- ============================================================ -->
+
+<text class="column-label-neg" x="980" y="88">WEAKENS REPUTATION</text>
+
+<!-- Negative 1: Spam Reports — engagement -->
+<g id="signal-spam-reports"
+   aria-label="Negative signal: spam reports are the strongest negative signal and directly damage reputation"
+   data-step="signal-negative"
+   data-label="Spam Reports"
+   data-description="Recipients marking messages as spam is the most damaging signal"
+   data-feeds="sender-reputation">
+  <rect class="neg-box" x="820" y="105" width="320" height="56" rx="8"/>
+  <rect class="neg-box-inner" x="824" y="109" width="312" height="48" rx="6"/>
+  <text class="signal-type-r" x="1120" y="118">ENGAGEMENT</text>
+  <text class="signal-label-r" x="1120" y="136">Spam Reports</text>
+  <text class="signal-sub-r" x="1120" y="150">Mark-as-spam actions</text>
+</g>
+
+<!-- Negative 2: Hard Bounces — operational -->
+<g id="signal-bounces"
+   aria-label="Negative signal: hard bounces to invalid addresses indicate poor list management"
+   data-step="signal-negative"
+   data-label="Hard Bounces"
+   data-description="Sending to invalid addresses signals poor list quality"
+   data-feeds="sender-reputation">
+  <rect class="neg-box" x="820" y="172" width="320" height="56" rx="8"/>
+  <rect class="neg-box-inner" x="824" y="176" width="312" height="48" rx="6"/>
+  <text class="signal-type-r" x="1120" y="185">OPERATIONAL</text>
+  <text class="signal-label-r" x="1120" y="203">Hard Bounces</text>
+  <text class="signal-sub-r" x="1120" y="217">Invalid address sends</text>
+</g>
+
+<!-- Negative 3: Spam Trap Hits — operational -->
+<g id="signal-spam-traps"
+   aria-label="Negative signal: spam trap hits indicate list sourcing or hygiene problems"
+   data-step="signal-negative"
+   data-label="Spam Trap Hits"
+   data-description="Sending to trap addresses indicates serious list quality or sourcing issues"
+   data-feeds="sender-reputation">
+  <rect class="neg-box" x="820" y="239" width="320" height="56" rx="8"/>
+  <rect class="neg-box-inner" x="824" y="243" width="312" height="48" rx="6"/>
+  <text class="signal-type-r" x="1120" y="252">OPERATIONAL</text>
+  <text class="signal-label-r" x="1120" y="270">Spam Trap Hits</text>
+  <text class="signal-sub-r" x="1120" y="284">List quality red flag</text>
+</g>
+
+<!-- Negative 4: Blocklist Appearances — infrastructure -->
+<g id="signal-blocklists"
+   aria-label="Negative signal: blocklist appearances severely damage deliverability and trust"
+   data-step="signal-negative"
+   data-label="Blocklist Appearances"
+   data-description="IP or domain appearing on blocklists severely restricts deliverability"
+   data-feeds="sender-reputation">
+  <rect class="neg-box" x="820" y="306" width="320" height="56" rx="8"/>
+  <rect class="neg-box-inner" x="824" y="310" width="312" height="48" rx="6"/>
+  <text class="signal-type-r" x="1120" y="319">INFRASTRUCTURE</text>
+  <text class="signal-label-r" x="1120" y="337">Blocklist Appearances</text>
+  <text class="signal-sub-r" x="1120" y="351">IP or domain blocked</text>
+</g>
+
+<!-- Negative 5: Low Engagement Rate — engagement -->
+<g id="signal-low-engagement"
+   aria-label="Negative signal: persistently low engagement rates signal unwanted or irrelevant mail"
+   data-step="signal-negative"
+   data-label="Low Engagement Rate"
+   data-description="Persistent low open and interaction rates signal content is unwanted"
+   data-feeds="sender-reputation">
+  <rect class="neg-box" x="820" y="373" width="320" height="56" rx="8"/>
+  <rect class="neg-box-inner" x="824" y="377" width="312" height="48" rx="6"/>
+  <text class="signal-type-r" x="1120" y="386">ENGAGEMENT</text>
+  <text class="signal-label-r" x="1120" y="404">Low Engagement Rate</text>
+  <text class="signal-sub-r" x="1120" y="418">Persistent disinterest</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- CONVERGENCE ARROWS -->
+<!-- ============================================================ -->
+
+<!-- Positive → Reputation -->
+<circle class="connector-dot" cx="380" cy="265" r="3" aria-hidden="true"/>
+<line class="arrow-pos" x1="383" y1="265" x2="430" y2="490"/>
+<text class="converge-label" x="385" y="460">Strengthens</text>
+
+<!-- Negative → Reputation -->
+<circle class="connector-dot-neg" cx="820" cy="265" r="3" aria-hidden="true"/>
+<line class="arrow-neg" x1="817" y1="265" x2="770" y2="490"/>
+<text class="converge-label-neg" x="815" y="460">Weakens</text>
+
+<!-- ============================================================ -->
+<!-- SENDER REPUTATION (central) -->
+<!-- ============================================================ -->
+
+<g id="sender-reputation"
+   aria-label="Sender reputation: cumulative trust score calculated by weighing positive signals against negative signals"
+   data-step="decision"
+   data-label="Sender Reputation"
+   data-description="Cumulative trust score combining positive and negative signals over time">
+
+  <rect class="rep-box" x="400" y="480" width="400" height="90" rx="12"/>
+  <text class="rep-text" x="600" y="515">Sender Reputation</text>
+  <text class="rep-sub" x="600" y="542">Cumulative trust score</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- BRANCHING ARROWS (reputation → outcomes) -->
+<!-- ============================================================ -->
+
+<circle class="connector-dot" cx="600" cy="570" r="3" aria-hidden="true"/>
+<line class="arrow-branch" x1="600" y1="573" x2="370" y2="618"/>
+<line class="arrow-branch" x1="600" y1="573" x2="600" y2="618"/>
+<line class="arrow-branch" x1="600" y1="573" x2="830" y2="618"/>
+
+<!-- ============================================================ -->
+<!-- OUTCOMES (grouped) -->
+<!-- ============================================================ -->
+
+<rect class="outcome-group" x="260" y="610" width="680" height="100" rx="14" aria-hidden="true"/>
+<text class="outcome-group-label" x="932" y="626">Placement outcomes</text>
+
+<g id="outcome-inbox"
+   aria-label="Outcome: Message delivered to inbox"
+   data-step="outcome"
+   data-label="Inbox"
+   data-description="Strong reputation results in inbox placement">
+  <rect class="outcome-inbox" x="275" y="625" width="195" height="72" rx="10"/>
+  <text class="outcome-label" x="372" y="653">Inbox</text>
+  <text class="outcome-sub" x="372" y="675">Primary delivery</text>
+</g>
+
+<g id="outcome-promotions"
+   aria-label="Outcome: Message delivered to promotions tab"
+   data-step="outcome"
+   data-label="Promotions"
+   data-description="Marketing content categorized into promotions tab">
+  <rect class="outcome-box" x="502" y="625" width="195" height="72" rx="10"/>
+  <text class="outcome-label" x="600" y="653">Promotions</text>
+  <text class="outcome-sub" x="600" y="675">Marketing tab</text>
+</g>
+
+<g id="outcome-spam"
+   aria-label="Outcome: Message delivered to spam folder"
+   data-step="outcome"
+   data-label="Spam"
+   data-description="Weak reputation results in spam folder placement">
+  <rect class="spam-outcome" x="730" y="625" width="195" height="72" rx="10"/>
+  <text class="spam-label" x="828" y="653">Spam</text>
+  <text class="outcome-sub" x="828" y="675">Spam folder</text>
+  <circle class="badge" cx="917" cy="632" r="9"/>
+  <text class="badge-text" x="917" y="633">!</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- ENGAGEMENT OBSERVATION LAYER -->
+<!-- ============================================================ -->
+
+<line class="arrow-down" x1="600" y1="710" x2="600" y2="745"/>
+
+<g id="engagement-signals"
+   aria-label="Post-placement: recipient engagement generates new positive and negative signals that feed back into reputation"
+   data-step="observation"
+   data-label="Engagement Signals"
+   data-description="Recipient behavior after delivery generates new signals that feed back into reputation"
+   data-feeds="sender-reputation">
+
+  <rect class="engagement-box" x="370" y="755" width="460" height="72" rx="10"/>
+  <text class="label" x="600" y="783">Engagement Signals</text>
+  <text class="sublabel" x="600" y="805">Opens · Replies · Rescues · Spam Complaints</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- DUAL FEEDBACK LOOPS -->
+<!-- ============================================================ -->
+
+<!-- Positive feedback: engagement → positive signals column -->
+<g id="loop-feedback-positive"
+   aria-label="Feedback: positive engagement actions feed back as positive signals for future messages">
+  <path class="feedback-pos"
+        d="M370 785
+           C280 780, 100 750, 60 650
+           C40 580, 40 480, 60 430"/>
+  <text class="feedback-label feedback-label-pos" x="120" y="620">Positive actions</text>
+  <text class="feedback-label feedback-label-pos" x="120" y="633">feed back</text>
+</g>
+
+<!-- Negative feedback: complaints → negative signals column -->
+<g id="loop-feedback-negative"
+   aria-label="Feedback: spam complaints feed back as negative signals for future messages">
+  <path class="feedback-neg"
+        d="M830 785
+           C920 780, 1100 750, 1140 650
+           C1160 580, 1160 480, 1140 430"/>
+  <text class="feedback-label feedback-label-neg" x="1080" y="620">Complaints</text>
+  <text class="feedback-label feedback-label-neg" x="1080" y="633">feed back</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- ATTRIBUTION -->
+<!-- ============================================================ -->
+
+<a href="https://www.inboxally.com">
+  <text class="attribution" x="36" y="900">Source: InboxAlly · inboxally.com</text>
+</a>
+<text class="attribution" x="1164" y="900" text-anchor="end">CC BY 4.0</text>
+
+</svg>

--- a/email-deliverability/diagrams/spam-filtering-pipeline.svg
+++ b/email-deliverability/diagrams/spam-filtering-pipeline.svg
@@ -1,0 +1,353 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:cc="http://creativecommons.org/ns#"
+     width="100%"
+     viewBox="0 0 1460 680"
+     xml:lang="en"
+     preserveAspectRatio="xMidYMid meet"
+     role="img"
+     aria-labelledby="title desc"
+     data-source="InboxAlly Deliverability Research">
+<title id="title">Spam Filtering Pipeline</title>
+<desc id="desc">
+Spam filtering pipeline: mailbox providers evaluate an email using several signal categories. Authentication alignment verifies SPF, DKIM, and DMARC. Content analysis examines copy, structure, and formatting. Link reputation checks the trustworthiness of URLs and domains. Sender reputation evaluates historical trust based on engagement, complaints, and sending behavior. Spam trap and complaint signals indicate potential abusive or low-quality sending. These inputs combine into a spam score and placement decision, which routes the message to the inbox, promotions tab, or spam folder.
+</desc>
+<metadata>
+<rdf:RDF>
+  <cc:Work rdf:about="">
+    <dc:title>Spam Filtering Pipeline Diagram</dc:title>
+    <dc:creator>InboxAlly</dc:creator>
+    <dc:source>https://www.inboxally.com</dc:source>
+    <dc:subject>spam filtering, email deliverability, SPF, DKIM, DMARC, content analysis, link reputation, sender reputation, spam traps, complaint rate, inbox placement, promotions tab, spam folder</dc:subject>
+    <dc:description>Diagram illustrating the signal inputs mailbox providers evaluate during spam filtering and how those signals feed into message placement outcomes.</dc:description>
+    <cc:license rdf:resource="https://creativecommons.org/licenses/by/4.0/" />
+  </cc:Work>
+</rdf:RDF>
+</metadata>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Spam Filtering Pipeline",
+  "description": "How mailbox providers evaluate authentication, content, links, reputation, and abuse signals to determine inbox placement.",
+  "publisher": {
+    "@type": "Organization",
+    "name": "InboxAlly",
+    "url": "https://www.inboxally.com"
+  },
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Authentication Alignment",
+      "text": "Mailbox providers check SPF, DKIM, and DMARC alignment to verify sender identity and domain legitimacy."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Content Analysis",
+      "text": "Message copy, formatting, structure, and headers are analyzed for suspicious or low-quality patterns."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Link Reputation",
+      "text": "URLs and linked domains are evaluated for trust, historical abuse, and redirect behavior."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Sender Reputation",
+      "text": "Historical signals such as engagement, complaint rate, and sending consistency are used to assess sender trust."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Spam Trap and Complaint Signals",
+      "text": "Spam traps, abuse complaints, and other negative indicators increase risk and can heavily influence filtering."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Spam Score and Placement",
+      "text": "These signals combine into an overall filtering decision that routes the message to the inbox, promotions tab, or spam folder."
+    }
+  ]
+}
+</script>
+<style>
+  /* === Light mode === */
+  .bg { fill: #F1F0ED; }
+  .header-bar { fill: #292929; }
+  .header-text { font-family: Georgia, "Times New Roman", serif; font-size: 24px; fill: #FFFFFF; dominant-baseline: middle; }
+  .header-sub { font-family: Arial, Helvetica, sans-serif; font-size: 13px; fill: #DDEFFF; letter-spacing: 1px; dominant-baseline: middle; }
+  .pipeline-axis { stroke: #D8D6D0; stroke-width: 2; }
+  .box { fill: #DDEFFF; stroke: #292929; stroke-width: 2; rx: 14; }
+  .box-inner { fill: none; stroke: #0062FF; stroke-opacity: 0.14; stroke-width: 2; rx: 10; }
+  .outcome { fill: #FFFFFF; stroke: #292929; stroke-width: 2; rx: 12; }
+  .spam-outcome { fill: #FFF0F0; stroke: #FF3333; stroke-width: 2; rx: 12; }
+  .decision-node { fill: #0062FF; }
+  .connector-dot { fill: #0062FF; }
+  .arrow { stroke: #0062FF; stroke-width: 3; marker-end: url(#arrowhead); }
+  .arrow-muted { stroke: #292929; stroke-opacity: 0.2; stroke-width: 1.5; stroke-dasharray: 6 3; fill: none; }
+  .text { font-family: Arial, Helvetica, sans-serif; fill: #292929; text-anchor: middle; dominant-baseline: middle; }
+  .stepnum { font-size: 14px; font-weight: 700; fill: #0062FF; }
+  .primary { font-size: 18px; }
+  .sub { font-size: 13px; opacity: 0.6; }
+  .tertiary { font-size: 12px; fill: #292929; }
+  .attribution { font-family: Arial, Helvetica, sans-serif; font-size: 11px; fill: #292929; opacity: 0.4; }
+  .badge { fill: #FF3333; }
+  .badge-text { font-family: Arial, Helvetica, sans-serif; font-size: 10px; font-weight: 700; fill: #FFFFFF; text-anchor: middle; dominant-baseline: middle; }
+  .icon { fill: #0062FF; opacity: 0.12; stroke: none; }
+  .diag-line { stroke: #0062FF; stroke-width: 0.5; opacity: 0.06; }
+  .feedback-label { font-family: Arial, Helvetica, sans-serif; font-size: 12px; fill: #0062FF; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+
+  /* === Dark mode === */
+  @media (prefers-color-scheme: dark) {
+    .bg { fill: #1A1A1A; }
+    .header-bar { fill: #0D0D0D; }
+    .box { fill: #1A2A3A; stroke: #4D9AFF; stroke-width: 1; }
+    .box-inner { stroke: #4D9AFF; stroke-opacity: 0.08; }
+    .text { fill: #E8E8E8; }
+    .sub { fill: #A0A0A0; }
+    .stepnum { fill: #4D9AFF; }
+    .icon { fill: #4D9AFF; opacity: 0.1; }
+    .arrow { stroke: #4D9AFF; }
+    .arrow-muted { stroke: #666666; }
+    .outcome { fill: #2A2A2A; stroke: #666666; }
+    .spam-outcome { fill: #3A1A1A; stroke: #FF6666; }
+    .primary { fill: #E8E8E8; }
+    .tertiary { fill: #888888; }
+    .decision-node { fill: #4D9AFF; }
+    .connector-dot { fill: #4D9AFF; }
+    .pipeline-axis { stroke: #333333; }
+    .diag-line { stroke: #4D9AFF; opacity: 0.04; }
+    .attribution { fill: #888888; }
+    .feedback-label { fill: #4D9AFF; }
+  }
+</style>
+<defs>
+  <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+    <polygon points="0 0, 10 3.5, 0 7" fill="#0062FF"/>
+  </marker>
+  <clipPath id="clip-canvas">
+    <rect x="0" y="0" width="1460" height="680"/>
+  </clipPath>
+</defs>
+
+<!-- Background -->
+<rect class="bg" x="0" y="0" width="1460" height="680"/>
+
+<!-- Diagonal line motif -->
+<g clip-path="url(#clip-canvas)" aria-hidden="true">
+  <line class="diag-line" x1="-50" y1="680" x2="350" y2="0"/>
+  <line class="diag-line" x1="50" y1="680" x2="450" y2="0"/>
+  <line class="diag-line" x1="150" y1="680" x2="550" y2="0"/>
+  <line class="diag-line" x1="250" y1="680" x2="650" y2="0"/>
+  <line class="diag-line" x1="350" y1="680" x2="750" y2="0"/>
+  <line class="diag-line" x1="450" y1="680" x2="850" y2="0"/>
+  <line class="diag-line" x1="550" y1="680" x2="950" y2="0"/>
+  <line class="diag-line" x1="650" y1="680" x2="1050" y2="0"/>
+  <line class="diag-line" x1="750" y1="680" x2="1150" y2="0"/>
+  <line class="diag-line" x1="850" y1="680" x2="1250" y2="0"/>
+  <line class="diag-line" x1="950" y1="680" x2="1350" y2="0"/>
+  <line class="diag-line" x1="1050" y1="680" x2="1450" y2="0"/>
+</g>
+
+<!-- Header bar -->
+<rect class="header-bar" x="0" y="0" width="1460" height="54"/>
+<text class="header-text" x="36" y="29">Spam Filtering Pipeline</text>
+<text class="header-sub" x="1424" y="29" text-anchor="end">INBOXALLY DELIVERABILITY RESEARCH</text>
+
+<!-- Pipeline axis — aligned with arrow centerline at y=240 -->
+<line class="pipeline-axis" x1="110" y1="240" x2="1100" y2="240" aria-hidden="true"/>
+
+<!-- ============================================================ -->
+<!-- PIPELINE STAGES -->
+<!-- ============================================================ -->
+
+<!-- Step 1: Authentication Alignment -->
+<g id="stage-authentication"
+   aria-label="Step 1: Authentication alignment checks SPF, DKIM, and DMARC"
+   data-step="1"
+   data-label="Authentication Alignment"
+   data-description="Mailbox provider verifies SPF, DKIM, and DMARC alignment"
+   data-next="stage-content-analysis">
+  <rect class="box" x="40" y="180" width="220" height="120"/>
+  <rect class="box-inner" x="46" y="186" width="208" height="108"/>
+  <text class="text stepnum" x="74" y="206">01</text>
+  <rect class="icon" x="170" y="198" width="54" height="34" rx="4" aria-hidden="true"/>
+  <polygon class="icon" points="170,198 197,220 224,198" aria-hidden="true"/>
+  <text class="text primary" x="150" y="236">Authentication</text>
+  <text class="text primary" x="150" y="258">Alignment</text>
+  <text class="text sub" x="150" y="284">SPF • DKIM • DMARC</text>
+</g>
+
+<!-- Step 2: Content Analysis -->
+<g id="stage-content-analysis"
+   aria-label="Step 2: Content analysis evaluates message copy, structure, and formatting"
+   data-step="2"
+   data-label="Content Analysis"
+   data-description="Mailbox providers analyze message content and formatting"
+   data-next="stage-link-reputation">
+  <rect class="box" x="300" y="180" width="220" height="120"/>
+  <rect class="box-inner" x="306" y="186" width="208" height="108"/>
+  <text class="text stepnum" x="334" y="206">02</text>
+  <rect class="icon" x="438" y="194" width="46" height="44" rx="4" aria-hidden="true"/>
+  <line x1="447" y1="208" x2="474" y2="208" stroke="#0062FF" stroke-opacity="0.12" stroke-width="5" aria-hidden="true"/>
+  <line x1="447" y1="221" x2="474" y2="221" stroke="#0062FF" stroke-opacity="0.12" stroke-width="5" aria-hidden="true"/>
+  <text class="text primary" x="410" y="246">Content Analysis</text>
+  <text class="text sub" x="410" y="274">Copy • Structure • Headers</text>
+</g>
+
+<!-- Step 3: Link Reputation -->
+<g id="stage-link-reputation"
+   aria-label="Step 3: Link reputation checks the trustworthiness of URLs and domains"
+   data-step="3"
+   data-label="Link Reputation"
+   data-description="Mailbox providers assess URLs and linked domains"
+   data-next="stage-sender-reputation">
+  <rect class="box" x="560" y="180" width="220" height="120"/>
+  <rect class="box-inner" x="566" y="186" width="208" height="108"/>
+  <text class="text stepnum" x="594" y="206">03</text>
+  <circle class="icon" cx="724" cy="213" r="16" aria-hidden="true"/>
+  <circle class="icon" cx="705" cy="232" r="16" aria-hidden="true"/>
+  <text class="text primary" x="670" y="246">Link Reputation</text>
+  <text class="text sub" x="670" y="274">URLs • Domains • Redirects</text>
+</g>
+
+<!-- Step 4: Sender Reputation -->
+<g id="stage-sender-reputation"
+   aria-label="Step 4: Sender reputation measures historical trust signals"
+   data-step="4"
+   data-label="Sender Reputation"
+   data-description="Mailbox providers assess sender trust based on historical behavior"
+   data-next="stage-abuse-signals">
+  <rect class="box" x="820" y="180" width="220" height="120"/>
+  <rect class="box-inner" x="826" y="186" width="208" height="108"/>
+  <text class="text stepnum" x="854" y="206">04</text>
+  <polygon class="icon" points="973,195 988,225 958,225" aria-hidden="true"/>
+  <rect class="icon" x="950" y="228" width="31" height="18" rx="3" aria-hidden="true"/>
+  <text class="text primary" x="930" y="246">Sender Reputation</text>
+  <text class="text sub" x="930" y="274">Engagement • Complaints</text>
+</g>
+
+<!-- Step 5: Spam Trap & Complaint Signals -->
+<g id="stage-abuse-signals"
+   aria-label="Step 5: Spam trap and complaint signals indicate elevated risk"
+   data-step="5"
+   data-label="Spam Trap Signals"
+   data-description="Spam traps and complaints increase spam filtering risk"
+   data-next="decision-placement">
+  <rect class="box" x="1080" y="180" width="220" height="120"/>
+  <rect class="box-inner" x="1086" y="186" width="208" height="108"/>
+  <text class="text stepnum" x="1114" y="206">05</text>
+  <circle class="icon" cx="1240" cy="214" r="18" aria-hidden="true"/>
+  <text class="text primary" x="1190" y="236">Spam Trap &amp;</text>
+  <text class="text primary" x="1190" y="258">Complaint Signals</text>
+  <text class="text sub" x="1190" y="284">Abuse • Risk • Negatives</text>
+  <circle class="badge" cx="1274" cy="192" r="11"/>
+  <text class="badge-text" x="1274" y="193">!</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- FLOW ARROWS -->
+<!-- ============================================================ -->
+
+<!-- Authentication → Content Analysis -->
+<circle class="connector-dot" cx="260" cy="240" r="3" aria-hidden="true"/>
+<line class="arrow" x1="263" y1="240" x2="300" y2="240"/>
+
+<!-- Content Analysis → Link Reputation -->
+<circle class="connector-dot" cx="520" cy="240" r="3" aria-hidden="true"/>
+<line class="arrow" x1="523" y1="240" x2="560" y2="240"/>
+
+<!-- Link Reputation → Sender Reputation -->
+<circle class="connector-dot" cx="780" cy="240" r="3" aria-hidden="true"/>
+<line class="arrow" x1="783" y1="240" x2="820" y2="240"/>
+
+<!-- Sender Reputation → Abuse Signals -->
+<circle class="connector-dot" cx="1040" cy="240" r="3" aria-hidden="true"/>
+<line class="arrow" x1="1043" y1="240" x2="1080" y2="240"/>
+
+<!-- Abuse Signals → Decision node -->
+<line class="arrow" x1="1190" y1="300" x2="1190" y2="409"/>
+
+<!-- ============================================================ -->
+<!-- DECISION NODE -->
+<!-- ============================================================ -->
+
+<g id="decision-placement"
+   aria-label="Decision: spam score and placement classification"
+   data-step="decision"
+   data-label="Spam Score"
+   data-description="Filtering decision routes message to final destination">
+  <circle class="decision-node" cx="1190" cy="420" r="11"/>
+  <text class="text tertiary" x="1190" y="446">Spam Score</text>
+</g>
+
+<!-- Decision → Outcomes -->
+<line class="arrow" x1="1190" y1="431" x2="1030" y2="500"/>
+<line class="arrow" x1="1190" y1="431" x2="1190" y2="500"/>
+<line class="arrow" x1="1190" y1="431" x2="1350" y2="500"/>
+
+<!-- ============================================================ -->
+<!-- OUTCOMES (all 160px wide) -->
+<!-- ============================================================ -->
+
+<!-- Inbox -->
+<g id="outcome-inbox"
+   aria-label="Outcome: Message delivered to inbox"
+   data-step="outcome"
+   data-label="Inbox"
+   data-description="Message delivered to the primary inbox">
+  <rect class="outcome" x="950" y="500" width="160" height="76"/>
+  <text class="text primary" x="1030" y="528">Inbox</text>
+  <text class="text sub" x="1030" y="550">Primary delivery</text>
+</g>
+
+<!-- Promotions -->
+<g id="outcome-promotions"
+   aria-label="Outcome: Message delivered to promotions tab"
+   data-step="outcome"
+   data-label="Promotions"
+   data-description="Message categorized into the promotions tab">
+  <rect class="outcome" x="1110" y="500" width="160" height="76"/>
+  <text class="text primary" x="1190" y="528">Promotions</text>
+  <text class="text sub" x="1190" y="550">Marketing tab</text>
+</g>
+
+<!-- Spam -->
+<g id="outcome-spam"
+   aria-label="Outcome: Message delivered to spam folder"
+   data-step="outcome"
+   data-label="Spam"
+   data-description="Message routed to the spam folder">
+  <rect class="spam-outcome" x="1270" y="500" width="160" height="76"/>
+  <text class="text primary" x="1350" y="528" style="fill:#FF3333;">Spam</text>
+  <text class="text sub" x="1350" y="550">Spam folder</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- FEEDBACK RELATIONSHIP -->
+<!-- ============================================================ -->
+
+<g id="loop-feedback-signals"
+   aria-label="Feedback: placement outcomes influence future filtering signals">
+  <line class="arrow-muted" x1="950" y1="550" x2="670" y2="318"/>
+  <text class="feedback-label" x="780" y="440">Influences future</text>
+  <text class="feedback-label" x="780" y="453">signal evaluation</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- ATTRIBUTION -->
+<!-- ============================================================ -->
+
+<a href="https://www.inboxally.com">
+  <text class="attribution" x="26" y="660">Source: InboxAlly · inboxally.com</text>
+</a>
+<text class="attribution" x="1434" y="660" text-anchor="end">CC BY 4.0</text>
+
+</svg>

--- a/email-deliverability/diagrams/spam-filtering-signals.svg
+++ b/email-deliverability/diagrams/spam-filtering-signals.svg
@@ -1,0 +1,407 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:cc="http://creativecommons.org/ns#"
+     width="100%"
+     viewBox="0 0 1200 780"
+     xml:lang="en"
+     preserveAspectRatio="xMidYMid meet"
+     role="img"
+     aria-labelledby="title desc"
+     data-source="InboxAlly Deliverability Research">
+
+<title id="title">Spam Filtering Signals</title>
+
+<desc id="desc">
+Spam filtering signal model: mailbox providers evaluate an incoming email against five parallel signal
+categories — authentication alignment (SPF, DKIM, DMARC), content analysis (copy, structure, headers),
+link reputation (URLs, domains, redirects), sender reputation (engagement history, complaint rate, sending
+consistency), and infrastructure signals (IP reputation, volume patterns, bounce rate). These signals are
+evaluated simultaneously, not sequentially, and combine into a composite spam score. The spam score
+determines message placement into the inbox, promotions tab, or spam folder. After placement, recipient
+engagement signals — opens, clicks, and spam complaints — are observed and feed back into the spam
+score calculation for future messages, creating a continuous feedback cycle.
+</desc>
+
+<metadata>
+<rdf:RDF>
+  <cc:Work rdf:about="">
+    <dc:title>Spam Filtering Signals Diagram</dc:title>
+    <dc:creator>InboxAlly</dc:creator>
+    <dc:source>https://www.inboxally.com</dc:source>
+    <dc:subject>spam filtering, email deliverability, SPF, DKIM, DMARC, content analysis, link reputation, sender reputation, IP reputation, sending volume, bounce rate, spam score, inbox placement, promotions tab, spam folder, engagement feedback, opens, clicks, complaints</dc:subject>
+    <dc:description>Diagram showing five parallel signal categories converging into a spam score, determining placement outcomes, with post-delivery engagement feeding back into future scoring.</dc:description>
+    <cc:license rdf:resource="https://creativecommons.org/licenses/by/4.0/" />
+  </cc:Work>
+</rdf:RDF>
+</metadata>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Spam Filtering Signals",
+  "description": "How mailbox providers evaluate parallel signal categories to determine email placement, and how engagement feeds back into future scoring.",
+  "publisher": {
+    "@type": "Organization",
+    "name": "InboxAlly",
+    "url": "https://www.inboxally.com"
+  },
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Parallel Signal Evaluation",
+      "text": "Mailbox providers simultaneously evaluate five signal categories: authentication alignment (SPF, DKIM, DMARC), content analysis (copy, structure, headers), link reputation (URLs, domains, redirects), sender reputation (engagement, complaints, sending behavior), and infrastructure signals (IP reputation, volume patterns, bounce rate)."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Spam Score Calculation",
+      "text": "The results from all signal categories combine into a composite spam score representing the overall risk level of the message."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Placement Decision",
+      "text": "Based on the spam score, the message is routed to the inbox, promotions tab, or spam folder."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Engagement Observation",
+      "text": "After delivery, recipient actions — opens, clicks, and spam complaints — generate engagement signals that mailbox providers observe and record."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Feedback into Future Scoring",
+      "text": "Engagement signals feed back into the spam score calculation for future messages from the same sender, creating a continuous feedback cycle that rewards positive engagement and penalizes complaints."
+    }
+  ]
+}
+</script>
+
+<style>
+  /* === Light mode === */
+  .bg { fill: #F1F0ED; }
+  .header-bar { fill: #292929; }
+  .header-text { font-family: Georgia, "Times New Roman", serif; font-size: 24px; fill: #FFFFFF; dominant-baseline: middle; }
+  .header-sub { font-family: Arial, Helvetica, sans-serif; font-size: 13px; fill: #DDEFFF; letter-spacing: 1px; dominant-baseline: middle; }
+  .signal-box { fill: #DDEFFF; stroke: #292929; stroke-width: 1.5; }
+  .signal-box-inner { fill: none; stroke: #0062FF; stroke-width: 1; opacity: 0.15; }
+  .score-box { fill: #0062FF; stroke: none; }
+  .score-text { font-family: Arial, Helvetica, sans-serif; fill: #FFFFFF; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .score-sub { font-family: Arial, Helvetica, sans-serif; fill: #FFFFFF; font-size: 11px; text-anchor: middle; dominant-baseline: middle; opacity: 0.7; }
+  .outcome-box { fill: #FFFFFF; stroke: #292929; stroke-width: 1.5; }
+  .outcome-inbox { fill: #DDEFFF; stroke: #0062FF; stroke-width: 2; }
+  .spam-outcome { fill: #FFF0F0; stroke: #FF3333; stroke-width: 2; }
+  .engagement-box { fill: #DDEFFF; stroke: #0062FF; stroke-width: 1.5; stroke-dasharray: 6 3; }
+  .label { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .sublabel { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 13px; text-anchor: middle; dominant-baseline: middle; opacity: 0.6; }
+  .signal-tag { font-family: Arial, Helvetica, sans-serif; fill: #0062FF; font-size: 11px; font-weight: 600; text-anchor: middle; dominant-baseline: middle; }
+  .outcome-label { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .outcome-sub { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 13px; text-anchor: middle; dominant-baseline: middle; opacity: 0.45; }
+  .spam-label { font-family: Arial, Helvetica, sans-serif; fill: #FF3333; font-size: 18px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .arrow-line { stroke: #0062FF; stroke-width: 2; marker-end: url(#arrow); }
+  .arrow-converge { stroke: #0062FF; stroke-width: 2; fill: none; marker-end: url(#arrow); }
+  .arrow-branch { stroke: #0062FF; stroke-width: 2; marker-end: url(#arrow); }
+  .arrow-down { stroke: #0062FF; stroke-width: 2; marker-end: url(#arrow); }
+  .feedback-path { stroke: #0062FF; stroke-width: 2; fill: none; stroke-dasharray: 8 4; marker-end: url(#arrow); opacity: 0.7; }
+  .feedback-label { font-family: Arial, Helvetica, sans-serif; fill: #0062FF; font-size: 12px; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+  .connector-dot { fill: #0062FF; }
+  .icon { fill: #0062FF; opacity: 0.12; stroke: none; }
+  .diag-line { stroke: #0062FF; stroke-width: 0.5; opacity: 0.06; }
+  .attribution { font-family: Arial, Helvetica, sans-serif; font-size: 11px; fill: #292929; opacity: 0.4; }
+  .badge { fill: #FF3333; }
+  .badge-text { font-family: Arial, Helvetica, sans-serif; font-size: 10px; font-weight: 700; fill: #FFFFFF; text-anchor: middle; dominant-baseline: middle; }
+  .brace { stroke: #292929; stroke-width: 1.5; fill: none; opacity: 0.2; }
+  .outcome-group { fill: none; stroke: #292929; stroke-width: 1; stroke-dasharray: 4 3; opacity: 0.2; }
+  .outcome-group-label { font-family: Arial, Helvetica, sans-serif; fill: #292929; font-size: 11px; text-anchor: end; dominant-baseline: middle; opacity: 0.35; }
+
+  /* === Dark mode === */
+  @media (prefers-color-scheme: dark) {
+    .bg { fill: #1A1A1A; }
+    .header-bar { fill: #0D0D0D; }
+    .signal-box { fill: #1A2A3A; stroke: #4D9AFF; stroke-width: 1; }
+    .signal-box-inner { stroke: #4D9AFF; opacity: 0.08; }
+    .score-box { fill: #4D9AFF; }
+    .label { fill: #E8E8E8; }
+    .sublabel { fill: #A0A0A0; }
+    .signal-tag { fill: #4D9AFF; }
+    .icon { fill: #4D9AFF; opacity: 0.1; }
+    .arrow-line { stroke: #4D9AFF; }
+    .arrow-converge { stroke: #4D9AFF; }
+    .arrow-branch { stroke: #4D9AFF; }
+    .arrow-down { stroke: #4D9AFF; }
+    .outcome-box { fill: #2A2A2A; stroke: #666666; }
+    .outcome-inbox { fill: #1A2A3A; stroke: #4D9AFF; }
+    .spam-outcome { fill: #3A1A1A; stroke: #FF6666; }
+    .engagement-box { fill: #1A2A3A; stroke: #4D9AFF; }
+    .outcome-label { fill: #E8E8E8; }
+    .outcome-sub { fill: #888888; }
+    .spam-label { fill: #FF6666; }
+    .feedback-path { stroke: #4D9AFF; }
+    .feedback-label { fill: #4D9AFF; }
+    .connector-dot { fill: #4D9AFF; }
+    .diag-line { stroke: #4D9AFF; opacity: 0.04; }
+    .attribution { fill: #888888; }
+    .brace { stroke: #666666; }
+    .outcome-group { stroke: #555555; }
+    .outcome-group-label { fill: #666666; }
+  }
+</style>
+
+<defs>
+  <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+    <polygon points="0 0, 8 3, 0 6" fill="#0062FF"/>
+  </marker>
+  <clipPath id="clip-canvas">
+    <rect x="0" y="0" width="1200" height="780"/>
+  </clipPath>
+</defs>
+
+<!-- Background -->
+<rect class="bg" x="0" y="0" width="1200" height="780"/>
+
+<!-- Diagonal line motif -->
+<g clip-path="url(#clip-canvas)" aria-hidden="true">
+  <line class="diag-line" x1="-50" y1="780" x2="450" y2="0"/>
+  <line class="diag-line" x1="50" y1="780" x2="550" y2="0"/>
+  <line class="diag-line" x1="150" y1="780" x2="650" y2="0"/>
+  <line class="diag-line" x1="250" y1="780" x2="750" y2="0"/>
+  <line class="diag-line" x1="350" y1="780" x2="850" y2="0"/>
+  <line class="diag-line" x1="450" y1="780" x2="950" y2="0"/>
+  <line class="diag-line" x1="550" y1="780" x2="1050" y2="0"/>
+  <line class="diag-line" x1="650" y1="780" x2="1150" y2="0"/>
+  <line class="diag-line" x1="750" y1="780" x2="1250" y2="0"/>
+</g>
+
+<!-- Header bar -->
+<rect class="header-bar" x="0" y="0" width="1200" height="54"/>
+<text class="header-text" x="36" y="29">Spam Filtering Signals</text>
+<text class="header-sub" x="1164" y="29" text-anchor="end">INBOXALLY DELIVERABILITY RESEARCH</text>
+
+<!-- ============================================================ -->
+<!-- SIGNAL INPUTS (parallel, not sequential) -->
+<!-- ============================================================ -->
+
+<!-- Signal 1: Authentication Alignment -->
+<g id="signal-authentication"
+   aria-label="Signal: Authentication alignment checks SPF, DKIM, and DMARC"
+   data-step="signal"
+   data-label="Authentication Alignment"
+   data-description="Mailbox provider verifies SPF, DKIM, and DMARC alignment"
+   data-feeds="decision-spam-score">
+
+  <rect class="signal-box" x="40" y="90" width="440" height="80" rx="10"/>
+  <rect class="signal-box-inner" x="44" y="94" width="432" height="72" rx="8"/>
+  <text class="signal-tag" x="80" y="113">SIGNAL</text>
+  <text class="label" x="270" y="122">Authentication Alignment</text>
+  <text class="sublabel" x="270" y="148">SPF · DKIM · DMARC</text>
+</g>
+
+<!-- Signal 2: Content Analysis -->
+<g id="signal-content"
+   aria-label="Signal: Content analysis evaluates message copy, structure, and headers"
+   data-step="signal"
+   data-label="Content Analysis"
+   data-description="Mailbox providers analyze message content and formatting"
+   data-feeds="decision-spam-score">
+
+  <rect class="signal-box" x="40" y="190" width="440" height="80" rx="10"/>
+  <rect class="signal-box-inner" x="44" y="194" width="432" height="72" rx="8"/>
+  <text class="signal-tag" x="80" y="213">SIGNAL</text>
+  <text class="label" x="270" y="222">Content Analysis</text>
+  <text class="sublabel" x="270" y="248">Copy · Structure · Headers</text>
+</g>
+
+<!-- Signal 3: Link Reputation -->
+<g id="signal-links"
+   aria-label="Signal: Link reputation checks the trustworthiness of URLs and domains"
+   data-step="signal"
+   data-label="Link Reputation"
+   data-description="Mailbox providers assess URLs and linked domains"
+   data-feeds="decision-spam-score">
+
+  <rect class="signal-box" x="40" y="290" width="440" height="80" rx="10"/>
+  <rect class="signal-box-inner" x="44" y="294" width="432" height="72" rx="8"/>
+  <text class="signal-tag" x="80" y="313">SIGNAL</text>
+  <text class="label" x="270" y="322">Link Reputation</text>
+  <text class="sublabel" x="270" y="348">URLs · Domains · Redirects</text>
+</g>
+
+<!-- Signal 4: Sender Reputation -->
+<g id="signal-sender-reputation"
+   aria-label="Signal: Sender reputation measures historical trust signals including engagement and complaints"
+   data-step="signal"
+   data-label="Sender Reputation"
+   data-description="Mailbox providers assess sender trust based on historical behavior"
+   data-feeds="decision-spam-score">
+
+  <rect class="signal-box" x="40" y="390" width="440" height="80" rx="10"/>
+  <rect class="signal-box-inner" x="44" y="394" width="432" height="72" rx="8"/>
+  <text class="signal-tag" x="80" y="413">SIGNAL</text>
+  <text class="label" x="270" y="422">Sender Reputation</text>
+  <text class="sublabel" x="270" y="448">Engagement · Complaints · Consistency</text>
+</g>
+
+<!-- Signal 5: Infrastructure & Volume -->
+<g id="signal-infrastructure"
+   aria-label="Signal: Infrastructure and volume patterns including IP reputation, sending volume, and bounce rate"
+   data-step="signal"
+   data-label="Infrastructure &amp; Volume"
+   data-description="Mailbox providers evaluate IP reputation, sending patterns, and bounce rates"
+   data-feeds="decision-spam-score">
+
+  <rect class="signal-box" x="40" y="490" width="440" height="80" rx="10"/>
+  <rect class="signal-box-inner" x="44" y="494" width="432" height="72" rx="8"/>
+  <text class="signal-tag" x="80" y="513">SIGNAL</text>
+  <text class="label" x="270" y="522">Infrastructure &amp; Volume</text>
+  <text class="sublabel" x="270" y="548">IP Reputation · Sending Patterns · Bounces</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- CONVERGENCE ARROWS (all signals → spam score) -->
+<!-- ============================================================ -->
+
+<!-- Brace hint -->
+<path class="brace" d="M490 130 C520 130, 530 140, 530 170
+                        L530 310
+                        C530 325, 540 330, 550 330
+                        C540 330, 530 335, 530 350
+                        L530 490
+                        C530 520, 520 530, 490 530" aria-hidden="true"/>
+
+<circle class="connector-dot" cx="480" cy="130" r="3" aria-hidden="true"/>
+<line class="arrow-converge" x1="483" y1="130" x2="610" y2="310"/>
+
+<circle class="connector-dot" cx="480" cy="230" r="3" aria-hidden="true"/>
+<line class="arrow-converge" x1="483" y1="230" x2="610" y2="318"/>
+
+<circle class="connector-dot" cx="480" cy="330" r="3" aria-hidden="true"/>
+<line class="arrow-line" x1="483" y1="330" x2="610" y2="330"/>
+
+<circle class="connector-dot" cx="480" cy="430" r="3" aria-hidden="true"/>
+<line class="arrow-converge" x1="483" y1="430" x2="610" y2="342"/>
+
+<circle class="connector-dot" cx="480" cy="530" r="3" aria-hidden="true"/>
+<line class="arrow-converge" x1="483" y1="530" x2="610" y2="350"/>
+
+<!-- ============================================================ -->
+<!-- SPAM SCORE (central decision) -->
+<!-- ============================================================ -->
+
+<g id="decision-spam-score"
+   aria-label="Decision: all signals combine into a composite spam score that determines message placement"
+   data-step="decision"
+   data-label="Spam Score"
+   data-description="Composite filtering score combining all signal inputs">
+
+  <rect class="score-box" x="620" y="285" width="180" height="90" rx="12"/>
+  <text class="score-text" x="710" y="322">Spam Score</text>
+  <text class="score-sub" x="710" y="348">Composite signal</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- BRANCHING ARROWS (spam score → outcomes) -->
+<!-- ============================================================ -->
+
+<circle class="connector-dot" cx="800" cy="330" r="3" aria-hidden="true"/>
+<line class="arrow-branch" x1="803" y1="330" x2="900" y2="205"/>
+<line class="arrow-branch" x1="803" y1="330" x2="900" y2="330"/>
+<line class="arrow-branch" x1="803" y1="330" x2="900" y2="455"/>
+
+<!-- ============================================================ -->
+<!-- OUTCOMES (grouped — engagement comes from all placements) -->
+<!-- ============================================================ -->
+
+<!-- Outcome group container -->
+<rect class="outcome-group" x="895" y="155" width="280" height="358" rx="14" aria-hidden="true"/>
+<text class="outcome-group-label" x="1168" y="173">Placement outcomes</text>
+
+<!-- Inbox -->
+<g id="outcome-inbox"
+   aria-label="Outcome: Message delivered to inbox"
+   data-step="outcome"
+   data-label="Inbox"
+   data-description="Message delivered to the primary inbox">
+
+  <rect class="outcome-inbox" x="910" y="168" width="250" height="80" rx="10"/>
+  <text class="outcome-label" x="1035" y="200">Inbox</text>
+  <text class="outcome-sub" x="1035" y="224">Primary delivery</text>
+</g>
+
+<!-- Promotions -->
+<g id="outcome-promotions"
+   aria-label="Outcome: Message delivered to promotions tab"
+   data-step="outcome"
+   data-label="Promotions"
+   data-description="Message categorized into the promotions tab">
+
+  <rect class="outcome-box" x="910" y="290" width="250" height="80" rx="10"/>
+  <text class="outcome-label" x="1035" y="322">Promotions</text>
+  <text class="outcome-sub" x="1035" y="346">Marketing tab</text>
+</g>
+
+<!-- Spam -->
+<g id="outcome-spam"
+   aria-label="Outcome: Message delivered to spam folder"
+   data-step="outcome"
+   data-label="Spam"
+   data-description="Message routed to the spam folder">
+
+  <rect class="spam-outcome" x="910" y="418" width="250" height="80" rx="10"/>
+  <text class="spam-label" x="1035" y="450">Spam</text>
+  <text class="outcome-sub" x="1035" y="474">Spam folder</text>
+
+  <!-- Notification badge -->
+  <circle class="badge" cx="1152" cy="425" r="9"/>
+  <text class="badge-text" x="1152" y="426">!</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- ENGAGEMENT SIGNALS (post-placement observation layer) -->
+<!-- ============================================================ -->
+
+<!-- Arrow from outcome group bottom center → Engagement -->
+<line class="arrow-down" x1="1035" y1="513" x2="1035" y2="560"/>
+
+<g id="engagement-signals"
+   aria-label="Post-placement: recipient engagement signals observed after delivery including opens, clicks, and spam complaints"
+   data-step="observation"
+   data-label="Engagement Signals"
+   data-description="Recipient behavior observed after message delivery including opens, clicks, and spam complaints"
+   data-feeds="decision-spam-score">
+
+  <rect class="engagement-box" x="870" y="570" width="330" height="80" rx="10"/>
+  <text class="label" x="1035" y="602">Engagement Signals</text>
+  <text class="sublabel" x="1035" y="626">Opens · Clicks · Spam Complaints</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- FEEDBACK LOOP (engagement → spam score) -->
+<!-- ============================================================ -->
+
+<g id="loop-feedback-score"
+   aria-label="Feedback loop: engagement signals feed back into spam score for future messages">
+
+  <path class="feedback-path"
+        d="M870 610
+           C770 610, 730 570, 720 490
+           C712 430, 710 400, 710 375"/>
+  <text class="feedback-label" x="770" y="540">Feeds into future</text>
+  <text class="feedback-label" x="770" y="553">spam score</text>
+</g>
+
+<!-- ============================================================ -->
+<!-- ATTRIBUTION -->
+<!-- ============================================================ -->
+
+<a href="https://www.inboxally.com">
+  <text class="attribution" x="36" y="755">Source: InboxAlly · inboxally.com</text>
+</a>
+<text class="attribution" x="1164" y="755" text-anchor="end">CC BY 4.0</text>
+
+</svg>


### PR DESCRIPTION
## Summary
- Add 5 SVG diagrams to new `email-deliverability/diagrams/` path
- Covers: spam filtering signals, spam filtering pipeline, email deliverability flow, sender reputation model, domain vs IP reputation

## Test plan
- [ ] Verify SVGs render at `assets.inboxally.com/email-deliverability/diagrams/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)